### PR TITLE
Deflake battler-wamp and battler-service workflows

### DIFF
--- a/.github/workflows/battler-ai.yml
+++ b/.github/workflows/battler-ai.yml
@@ -1,0 +1,30 @@
+name: battler-ai
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  DATA_DIR: ${{ github.workspace }}/battle-data/data
+  CRATE_ROOT: ${{ github.workspace }}
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+jobs:
+  test-battler-ai:
+    name: Run battler-ai tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GEMINI_PYTHON_VENV: ${{ github.workspace }}/.venv
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: ./.github/actions/battler-ai-gemini-py
+      - name: Set up Rust
+        uses: ./.github/actions/rust
+      - name: Run battler-ai tests
+        run: cargo test -p "battler-ai*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ env:
   CARGO_TERM_COLOR: always
   DATA_DIR: ${{ github.workspace }}/battle-data/data
   CRATE_ROOT: ${{ github.workspace }}
-  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
 jobs:
   build-no-std:
@@ -129,21 +128,6 @@ jobs:
         uses: ./.github/actions/rust
       - name: Run battler-multiplayer-service tests
         run: cargo test -p "battler-multiplayer-service*"
-
-  test-battler-ai:
-    name: Run battler-ai tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      GEMINI_PYTHON_VENV: ${{ github.workspace }}/.venv
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: ./.github/actions/battler-ai-gemini-py
-      - name: Set up Rust
-        uses: ./.github/actions/rust
-      - name: Run battler-ai tests
-        run: cargo test -p "battler-ai*"
 
   test-battler-wamp:
     name: Run battler-wamp tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
   DATA_DIR: ${{ github.workspace }}/battle-data/data
   CRATE_ROOT: ${{ github.workspace }}
-  TOKIO_WORKER_THREADS: 4
+  TOKIO_WORKER_THREADS: 8
 
 jobs:
   build-no-std:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ env:
   CARGO_TERM_COLOR: always
   DATA_DIR: ${{ github.workspace }}/battle-data/data
   CRATE_ROOT: ${{ github.workspace }}
+  TOKIO_WORKER_THREADS: 4
 
 jobs:
   build-no-std:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,16 +100,16 @@ syn = { version = "2.0", features = ["full"] }
 battler-choice = { version = "0.3", default-features = false }
 battler-data = { version = "0.3", default-features = false }
 battler-prng = { version = "0.3", default-features = false, features = ["alloc"] }
-battler-wamp = "0.5"
-battler-wamp-uri = "0.1"
-battler-wamp-values = "~0.2.2"
-battler-wamprat = "0.7"
-battler-wamprat-error = "0.2"
-battler-wamprat-message = "~0.1.3"
-battler-wamprat-schema = "0.4"
-battler-wamprat-uri = "0.5"
-serde-struct-tuple = "~0.1.3"
-serde-struct-tuple-enum = "0.1"
+battler-wamp = { version = "0.5", path = "battler-wamp" }
+battler-wamp-uri = { version = "0.1", path = "battler-wamp/battler-wamp-uri" }
+battler-wamp-values = { version = "~0.2.2", path = "battler-wamp/battler-wamp-values" }
+battler-wamprat = { version = "0.7", path = "battler-wamprat" }
+battler-wamprat-error = { version = "0.2", path = "battler-wamprat/battler-wamprat-error" }
+battler-wamprat-message = { version = "~0.1.3", path = "battler-wamprat/battler-wamprat-message" }
+battler-wamprat-schema = { version = "0.4", path = "battler-wamprat-schema" }
+battler-wamprat-uri = { version = "0.5", path = "battler-wamprat/battler-wamprat-uri" }
+serde-struct-tuple = { version = "~0.1.3", path = "battler-wamp/serde-struct-tuple" }
+serde-struct-tuple-enum = { version = "0.1", path = "battler-wamp/serde-struct-tuple-enum" }
 
 [profile.test]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,9 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
 # Crates residing within this repository.
-battler-choice = { version = "0.3", default-features = false }
-battler-data = { version = "0.3", default-features = false }
-battler-prng = { version = "0.3", default-features = false, features = ["alloc"] }
+battler-choice = { version = "0.3", path = "battler-choice", default-features = false }
+battler-data = { version = "0.3", path = "battler-data", default-features = false }
+battler-prng = { version = "0.3", path = "battler-prng", default-features = false, features = ["alloc"] }
 battler-wamp = { version = "0.5", path = "battler-wamp" }
 battler-wamp-uri = { version = "0.1", path = "battler-wamp/battler-wamp-uri" }
 battler-wamp-values = { version = "~0.2.2", path = "battler-wamp/battler-wamp-values" }

--- a/battler-multiplayer-service-client/src/wamp.rs
+++ b/battler-multiplayer-service-client/src/wamp.rs
@@ -138,7 +138,7 @@ where
         &self,
         player: &str,
     ) -> Result<broadcast::Receiver<ProposedBattleUpdate>> {
-        let (update_tx, update_rx) = broadcast::channel(16);
+        let (update_tx, update_rx) = broadcast::channel(48);
         let pattern = battler_multiplayer_service_schema::ProposedBattleUpdatesPattern {
             player: player.to_owned(),
         };

--- a/battler-multiplayer-service/src/ai/ai_player.rs
+++ b/battler-multiplayer-service/src/ai/ai_player.rs
@@ -142,7 +142,7 @@ pub struct AiPlayer<'d> {
 impl<'d> AiPlayer<'d> {
     /// Creates a new player.
     pub fn new(id: String, options: AiPlayerOptions, modules: AiPlayerModules<'d>) -> Self {
-        let (error_tx, _) = broadcast::channel(16);
+        let (error_tx, _) = broadcast::channel(48);
         let (task_tx, task_rx) = mpsc::channel(1);
         Self {
             id,
@@ -164,7 +164,7 @@ impl<'d> AiPlayer<'d> {
     /// the returned handle.
     pub async fn start(self) -> Result<AiPlayerHandle<'d>> {
         let id = self.id.clone();
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let error_rx = self.error_tx.subscribe();
         let (task_tx, task_rx) = mpsc::channel(1);
 

--- a/battler-multiplayer-service/src/service.rs
+++ b/battler-multiplayer-service/src/service.rs
@@ -521,7 +521,7 @@ struct PlayerState {
 
 impl PlayerState {
     fn new() -> Self {
-        let (update_tx, _) = broadcast::channel(16);
+        let (update_tx, _) = broadcast::channel(48);
         Self {
             proposed_battles: BTreeSet::default(),
             update_tx,

--- a/battler-service-producer/tests/producer_test.rs
+++ b/battler-service-producer/tests/producer_test.rs
@@ -703,13 +703,18 @@ async fn publishes_battle_logs() {
         Vec::<String>::default()
     );
 
+    let mut player_1_side_1_log = read_all_entries_from_log_rx_stopping_at_line_or_timeout(
+        &mut player_1_side_1_rx,
+        "turn|turn:2",
+        Duration::from_secs(3),
+    )
+    .await;
+    assert_matches::assert_matches!(
+        player_1_side_1_log.pop(),
+        Some(line) if line.starts_with("-battlerservice:timer|battle|remainingsecs:")
+    );
     pretty_assertions::assert_eq!(
-        read_all_entries_from_log_rx_stopping_at_line_or_timeout(
-            &mut player_1_side_1_rx,
-            "turn|turn:2",
-            Duration::from_secs(3),
-        )
-        .await,
+        player_1_side_1_log,
         [
             "-battlerservice:started",
             "info|battletype:Singles",
@@ -732,17 +737,21 @@ async fn publishes_battle_logs() {
             "move|mon:Meowth,player-2,1|name:Scratch|target:Pikachu,player-1,1",
             "damage|mon:Pikachu,player-1,1|health:12/18",
             "residual",
-            "-battlerservice:timer|battle|remainingsecs:59",
         ]
     );
 
+    let mut player_2_side_2_log = read_all_entries_from_log_rx_stopping_at_line_or_timeout(
+        &mut player_2_side_2_rx,
+        "turn|turn:2",
+        Duration::from_secs(3),
+    )
+    .await;
+    assert_matches::assert_matches!(
+        player_2_side_2_log.pop(),
+        Some(line) if line.starts_with("-battlerservice:timer|battle|remainingsecs:")
+    );
     pretty_assertions::assert_eq!(
-        read_all_entries_from_log_rx_stopping_at_line_or_timeout(
-            &mut player_2_side_2_rx,
-            "turn|turn:2",
-            Duration::from_secs(3),
-        )
-        .await,
+        player_2_side_2_log,
         [
             "-battlerservice:started",
             "info|battletype:Singles",
@@ -765,17 +774,21 @@ async fn publishes_battle_logs() {
             "move|mon:Meowth,player-2,1|name:Scratch|target:Pikachu,player-1,1",
             "damage|mon:Pikachu,player-1,1|health:67/100",
             "residual",
-            "-battlerservice:timer|battle|remainingsecs:59",
         ]
     );
 
+    let mut public_log = read_all_entries_from_log_rx_stopping_at_line_or_timeout(
+        &mut public_rx,
+        "turn|turn:2",
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_matches::assert_matches!(
+        public_log.pop(),
+        Some(line) if line.starts_with("-battlerservice:timer|battle|remainingsecs:")
+    );
     pretty_assertions::assert_eq!(
-        read_all_entries_from_log_rx_stopping_at_line_or_timeout(
-            &mut public_rx,
-            "turn|turn:2",
-            Duration::from_secs(5),
-        )
-        .await,
+        public_log,
         [
             "-battlerservice:started",
             "info|battletype:Singles",
@@ -798,7 +811,6 @@ async fn publishes_battle_logs() {
             "move|mon:Meowth,player-2,1|name:Scratch|target:Pikachu,player-1,1",
             "damage|mon:Pikachu,player-1,1|health:67/100",
             "residual",
-            "-battlerservice:timer|battle|remainingsecs:59",
         ]
     );
 }

--- a/battler-service-producer/tests/producer_test.rs
+++ b/battler-service-producer/tests/producer_test.rs
@@ -379,6 +379,8 @@ async fn read_all_entries_from_log_rx_stopping_at_line_or_timeout(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lists_battles() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let consumer = start_consumer(
@@ -406,6 +408,8 @@ async fn lists_battles() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn authorizes_battle_creation() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let consumer = start_consumer(
@@ -438,6 +442,8 @@ async fn authorizes_battle_creation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn creates_battle() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(
@@ -495,6 +501,8 @@ async fn creates_battle() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_can_start_and_delete_battle() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(
@@ -564,6 +572,8 @@ async fn owner_can_start_and_delete_battle() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_can_update_team() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(
@@ -607,6 +617,8 @@ async fn player_can_update_team() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_can_participate_in_battle() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(
@@ -653,6 +665,8 @@ async fn player_can_participate_in_battle() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publishes_battle_logs() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(
@@ -861,6 +875,8 @@ async fn publishes_battle_logs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remote_connection_cannot_publish_battle_log() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let mut connection = PeerConnectionConfig::new(PeerConnectionType::Remote(format!(
@@ -890,6 +906,8 @@ async fn remote_connection_cannot_publish_battle_log() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_reads_full_log() {
+    battler_test_utils::collect_logs();
+
     let mut context = TestContext::new().await;
     context.run_producer().await;
     let player_1 = new_client(

--- a/battler-service-producer/tests/producer_test.rs
+++ b/battler-service-producer/tests/producer_test.rs
@@ -229,9 +229,12 @@ async fn start_consumer<S>(
 where
     S: Send + 'static,
 {
+    let mut connection = PeerConnectionConfig::new(connection_type);
+    connection.reconnect_delay = Duration::from_millis(50);
+    connection.max_consecutive_failures = 100;
     let consumer = BattlerService::consumer(
         battler_wamprat_schema::PeerConfig {
-            connection: PeerConnectionConfig::new(connection_type),
+            connection,
             auth_methods: Vec::from_iter([battler_wamp::peer::SupportedAuthMethod::Undisputed {
                 id: name.to_owned(),
                 role: "user".to_owned(),
@@ -860,11 +863,14 @@ async fn publishes_battle_logs() {
 async fn remote_connection_cannot_publish_battle_log() {
     let mut context = TestContext::new().await;
     context.run_producer().await;
+    let mut connection = PeerConnectionConfig::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        context.router_handle.local_addr()
+    )));
+    connection.reconnect_delay = Duration::from_millis(50);
+    connection.max_consecutive_failures = 100;
     let bad_producer = BattlerService::producer_builder(PeerConfig {
-        connection: PeerConnectionConfig::new(PeerConnectionType::Remote(format!(
-            "ws://{}",
-            context.router_handle.local_addr()
-        ))),
+        connection,
         auth_methods: Vec::default(),
     })
     .start(create_peer("player-1").unwrap())

--- a/battler-service-producer/tests/producer_test.rs
+++ b/battler-service-producer/tests/producer_test.rs
@@ -174,7 +174,14 @@ impl TestContext {
     async fn run_producer(&mut self) {
         let (stop_tx, stop_rx) = broadcast::channel(1);
         let data = static_local_data_store();
-        let peer = new_web_socket_peer(battler_wamp::peer::PeerConfig::default()).unwrap();
+        let peer = new_web_socket_peer(battler_wamp::peer::PeerConfig {
+            name: format!(
+                "producer-{}",
+                std::thread::current().name().unwrap_or("NO_THREAD_NAME")
+            ),
+            ..Default::default()
+        })
+        .unwrap();
         let config = battler_wamprat_schema::PeerConfig {
             connection: PeerConnectionConfig::new(PeerConnectionType::Direct(
                 self.router_handle.clone(),
@@ -215,7 +222,10 @@ impl TestContext {
 
 fn create_peer(name: &str) -> Result<WebSocketPeer> {
     let config = battler_wamp::peer::PeerConfig {
-        name: name.to_owned(),
+        name: format!(
+            "{name}-{}",
+            std::thread::current().name().unwrap_or("NO_THREAD_NAME")
+        ),
         ..Default::default()
     };
     new_web_socket_peer(config)

--- a/battler-service-producer/tests/producer_test.rs
+++ b/battler-service-producer/tests/producer_test.rs
@@ -153,30 +153,64 @@ impl BattleAuthorizer for Authorizer {
     }
 }
 
-async fn run_producer(router: RouterHandle) -> Result<JoinHandle<Result<()>>> {
-    let data = static_local_data_store();
-    let peer = new_web_socket_peer(battler_wamp::peer::PeerConfig::default())?;
-    let config = battler_wamprat_schema::PeerConfig {
-        connection: PeerConnectionConfig::new(PeerConnectionType::Direct(router)),
-        auth_methods: Vec::default(),
-    };
-    let (started_tx, started_rx) = oneshot::channel();
-    let handle = tokio::spawn(run_battler_service_producer(
-        data,
-        CoreBattleEngineOptions {
-            log_time: false,
-            ..Default::default()
-        },
-        config,
-        peer,
-        Modules {
-            authorizer: Box::new(Authorizer),
-            stop_rx: None,
-            started_tx: Some(started_tx),
-        },
-    ));
-    started_rx.await?;
-    Ok(handle)
+struct TestContext {
+    router_handle: RouterHandle,
+    router_join_handle: JoinHandle<()>,
+    producer_stop_tx: Option<broadcast::Sender<()>>,
+    producer_join_handle: Option<JoinHandle<Result<()>>>,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let (router_handle, router_join_handle) = start_router().await.unwrap();
+        Self {
+            router_handle,
+            router_join_handle,
+            producer_stop_tx: None,
+            producer_join_handle: None,
+        }
+    }
+
+    async fn run_producer(&mut self) {
+        let (stop_tx, stop_rx) = broadcast::channel(1);
+        let data = static_local_data_store();
+        let peer = new_web_socket_peer(battler_wamp::peer::PeerConfig::default()).unwrap();
+        let config = battler_wamprat_schema::PeerConfig {
+            connection: PeerConnectionConfig::new(PeerConnectionType::Direct(
+                self.router_handle.clone(),
+            )),
+            auth_methods: Vec::default(),
+        };
+        let (started_tx, started_rx) = oneshot::channel();
+        let handle = tokio::spawn(run_battler_service_producer(
+            data,
+            CoreBattleEngineOptions {
+                log_time: false,
+                ..Default::default()
+            },
+            config,
+            peer,
+            Modules {
+                authorizer: Box::new(Authorizer),
+                stop_rx: Some(stop_rx),
+                started_tx: Some(started_tx),
+            },
+        ));
+        started_rx.await.unwrap();
+        self.producer_stop_tx = Some(stop_tx);
+        self.producer_join_handle = Some(handle);
+    }
+
+    async fn teardown(self) {
+        if let Some(stop_tx) = self.producer_stop_tx {
+            stop_tx.send(()).ok();
+        }
+        if let Some(handle) = self.producer_join_handle {
+            handle.await.ok();
+        }
+        self.router_handle.cancel().ok();
+        self.router_join_handle.await.ok();
+    }
 }
 
 fn create_peer(name: &str) -> Result<WebSocketPeer> {
@@ -342,11 +376,11 @@ async fn read_all_entries_from_log_rx_stopping_at_line_or_timeout(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lists_battles() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let consumer = start_consumer(
         "player-1",
-        PeerConnectionType::Remote(format!("ws://{}", router_handle.local_addr())),
+        PeerConnectionType::Remote(format!("ws://{}", context.router_handle.local_addr())),
         create_peer("player-1").unwrap(),
     )
     .await
@@ -364,15 +398,16 @@ async fn lists_battles() {
             });
         }
     );
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn authorizes_battle_creation() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let consumer = start_consumer(
         "player-1",
-        PeerConnectionType::Remote(format!("ws://{}", router_handle.local_addr())),
+        PeerConnectionType::Remote(format!("ws://{}", context.router_handle.local_addr())),
         create_peer("player-1").unwrap(),
     )
     .await
@@ -395,16 +430,17 @@ async fn authorizes_battle_creation() {
             });
         }
     );
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn creates_battle() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -413,7 +449,7 @@ async fn creates_battle() {
     let player_2 = new_client(
         start_consumer(
             "player-2",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-2").unwrap(),
         )
         .await
@@ -451,16 +487,17 @@ async fn creates_battle() {
             pretty_assertions::assert_eq!(battles, []);
         }
     );
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_can_start_and_delete_battle() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -469,7 +506,7 @@ async fn owner_can_start_and_delete_battle() {
     let player_2 = new_client(
         start_consumer(
             "player-2",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-2").unwrap(),
         )
         .await
@@ -519,16 +556,17 @@ async fn owner_can_start_and_delete_battle() {
     assert_matches::assert_matches!(player_2.battles(usize::MAX, 0).await, Ok(battles) => {
         pretty_assertions::assert_eq!(battles, []);
     });
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_can_update_team() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -561,16 +599,17 @@ async fn player_can_update_team() {
             assert_eq!(err.to_string(), "player-1 cannot act as player-2");
         }
     );
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_can_participate_in_battle() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -606,16 +645,17 @@ async fn player_can_participate_in_battle() {
     assert_matches::assert_matches!(player_1.make_choice(battle.uuid, "player-2", "move 0").await, Err(err) => {
         assert_eq!(err.to_string(), "player-1 cannot act as player-2");
     });
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publishes_battle_logs() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -624,7 +664,7 @@ async fn publishes_battle_logs() {
     let player_2 = new_client(
         start_consumer(
             "player-2",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-2").unwrap(),
         )
         .await
@@ -633,7 +673,7 @@ async fn publishes_battle_logs() {
     let player_3 = new_client(
         start_consumer(
             "player-3",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-3").unwrap(),
         )
         .await
@@ -813,16 +853,17 @@ async fn publishes_battle_logs() {
             "residual",
         ]
     );
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remote_connection_cannot_publish_battle_log() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let bad_producer = BattlerService::producer_builder(PeerConfig {
         connection: PeerConnectionConfig::new(PeerConnectionType::Remote(format!(
             "ws://{}",
-            router_handle.local_addr()
+            context.router_handle.local_addr()
         ))),
         auth_methods: Vec::default(),
     })
@@ -838,16 +879,17 @@ async fn remote_connection_cannot_publish_battle_log() {
     ).await, Err(err) => {
         assert_eq!(err.to_string(), "remote connection cannot publish");
     });
+    context.teardown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn player_reads_full_log() {
-    let (router_handle, _) = start_router().await.unwrap();
-    run_producer(router_handle.clone()).await.unwrap();
+    let mut context = TestContext::new().await;
+    context.run_producer().await;
     let player_1 = new_client(
         start_consumer(
             "player-1",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-1").unwrap(),
         )
         .await
@@ -856,7 +898,7 @@ async fn player_reads_full_log() {
     let player_2 = new_client(
         start_consumer(
             "player-2",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-2").unwrap(),
         )
         .await
@@ -865,7 +907,7 @@ async fn player_reads_full_log() {
     let player_3 = new_client(
         start_consumer(
             "player-3",
-            PeerConnectionType::Direct(router_handle.clone()),
+            PeerConnectionType::Direct(context.router_handle.clone()),
             create_peer("player-3").unwrap(),
         )
         .await
@@ -938,4 +980,5 @@ async fn player_reads_full_log() {
             assert_eq!(err.to_string(), "player-3 is not on given side");
         }
     );
+    context.teardown().await;
 }

--- a/battler-service/src/api.rs
+++ b/battler-service/src/api.rs
@@ -45,7 +45,7 @@ pub struct Side {
 }
 
 /// The state of a [`Battle`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BattleState {
     /// The battle is being prepared.
     #[serde(rename = "preparing")]

--- a/battler-service/src/service.rs
+++ b/battler-service/src/service.rs
@@ -1120,10 +1120,7 @@ impl<'d> BattlerService<'d> {
         Ok(battle.log_for_side(side, |log| log.subscribe()).await)
     }
 
-    fn unwrap_battle(
-        battle: Arc<LiveBattleManager<'d>>,
-        context: &str,
-    ) -> LiveBattleManager<'d> {
+    fn unwrap_battle(battle: Arc<LiveBattleManager<'d>>, context: &str) -> LiveBattleManager<'d> {
         let mut battle_opt = Some(battle);
         for _ in 0..1000 {
             match Arc::try_unwrap(battle_opt.take().unwrap()) {

--- a/battler-service/src/service.rs
+++ b/battler-service/src/service.rs
@@ -1120,6 +1120,23 @@ impl<'d> BattlerService<'d> {
         Ok(battle.log_for_side(side, |log| log.subscribe()).await)
     }
 
+    fn unwrap_battle(
+        battle: Arc<LiveBattleManager<'d>>,
+        context: &str,
+    ) -> LiveBattleManager<'d> {
+        let mut battle_opt = Some(battle);
+        for _ in 0..1000 {
+            match Arc::try_unwrap(battle_opt.take().unwrap()) {
+                Ok(battle) => return battle,
+                Err(battle_arc) => {
+                    battle_opt = Some(battle_arc);
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            }
+        }
+        panic!("battle could not be unwrapped during {context} (leaked references exist)");
+    }
+
     /// Deletes a battle.
     pub async fn delete(&self, battle: Uuid) -> Result<()> {
         {
@@ -1139,11 +1156,7 @@ impl<'d> BattlerService<'d> {
             // SAFETY: Must call shutdown here to join all tasks that are using the battle, so that
             // the battle does not outlive this object.
             battle.shutdown().await;
-            let battle = Arc::try_unwrap(battle)
-                .map_err(|_| {
-                    Error::msg("battle could not be unwrapped during deletion after shutdown")
-                })
-                .unwrap();
+            let battle = tokio::task::block_in_place(|| Self::unwrap_battle(battle, "deletion"));
 
             let players = battle.players().await;
             for player in players {
@@ -1217,11 +1230,7 @@ impl Drop for BattlerService<'_> {
                 // SAFETY: Must synchronously cancel and wait for tasks to finish, so that the
                 // battle does not outlive this object.
                 battle.cancel();
-                Arc::try_unwrap(battle)
-                    .map_err(|_| {
-                        Error::msg("battle could not be unwrapped during drop after cancel")
-                    })
-                    .unwrap();
+                Self::unwrap_battle(battle, "drop after cancel");
             }
         });
     }

--- a/battler-service/src/service.rs
+++ b/battler-service/src/service.rs
@@ -125,8 +125,8 @@ impl<'d> LiveBattle<'d> {
         let battle = PublicCoreBattle::new(options, data, engine_options)?;
         let logs = SplitLogs::new(uuid, sides.len(), global_log_tx);
 
-        let (choice_made_tx, _) = broadcast::channel(16);
-        let (cancel_timers_tx, _) = broadcast::channel(16);
+        let (choice_made_tx, _) = broadcast::channel(48);
+        let (cancel_timers_tx, _) = broadcast::channel(48);
 
         let players = sides
             .iter()

--- a/battler-service/src/service.rs
+++ b/battler-service/src/service.rs
@@ -883,9 +883,15 @@ impl<'d> LiveBattleManager<'d> {
 
     async fn shutdown(&self) {
         log::trace!("Shutting down live battle {}", self.uuid);
-        let mut state = self.state.lock().await;
-        state.proceed_tasks.shutdown().await;
-        state.current_timer_tasks.shutdown().await;
+        let (mut proceed_tasks, mut current_timer_tasks) = {
+            let mut state = self.state.lock().await;
+            (
+                std::mem::replace(&mut state.proceed_tasks, JoinSet::new()),
+                std::mem::replace(&mut state.current_timer_tasks, JoinSet::new()),
+            )
+        };
+        proceed_tasks.shutdown().await;
+        current_timer_tasks.shutdown().await;
     }
 
     fn cancel(&self) {
@@ -985,7 +991,7 @@ impl<'d> BattlerService<'d> {
     ///
     /// All log entries for all battles will be sent over this channel for consumption.
     ///
-    /// This method can only be called once. Subsequent calls will return [`None`],
+    /// This method can only be called once. Subsequent calls will return [`None`].
     pub fn take_global_log_rx(&mut self) -> Option<mpsc::UnboundedReceiver<GlobalLogEntry>> {
         self.global_log_rx.take()
     }

--- a/battler-service/src/service.rs
+++ b/battler-service/src/service.rs
@@ -96,6 +96,7 @@ enum TimerLogType {
 /// For non-atomic operations, the [`LiveBattleManager`] may make mutations to state in this object.
 struct LiveBattle<'d> {
     uuid: Uuid,
+    state: BattleState,
     battle: PublicCoreBattle<'d>,
     metadata: BattleMetadata,
     sides: Vec<Side>,
@@ -139,6 +140,7 @@ impl<'d> LiveBattle<'d> {
 
         LiveBattle {
             uuid,
+            state: BattleState::Preparing,
             battle,
             metadata,
             sides,
@@ -192,13 +194,7 @@ impl<'d> LiveBattle<'d> {
     }
 
     fn battle_state(&self) -> BattleState {
-        if !self.battle.started() {
-            BattleState::Preparing
-        } else if !self.battle.ended() {
-            BattleState::Active
-        } else {
-            BattleState::Finished
-        }
+        self.state
     }
 
     fn battle_status(&self) -> BattleStatus {
@@ -306,6 +302,9 @@ impl<'d> LiveBattle<'d> {
             false
         };
         self.update_log();
+        if self.battle.ended() {
+            self.state = BattleState::Finished;
+        }
         Ok(continued)
     }
 
@@ -476,6 +475,7 @@ impl<'d> LiveBattleManager<'d> {
             live_battle.battle.start()?;
             live_battle.inject_log_entries(["started"]);
             live_battle.update_log();
+            live_battle.state = BattleState::Active;
         }
         Self::proceed(
             self.live_battle.clone(),

--- a/battler-service/tests/service_test.rs
+++ b/battler-service/tests/service_test.rs
@@ -296,11 +296,12 @@ async fn starts_battle_and_reports_player_and_request_data() {
         .await
         .unwrap();
 
+    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
+
     assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for battle to start.
-    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
-    assert_matches::assert_matches!(public_log_rx.recv().await, Ok(_));
+    read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "turn|turn:1").await;
 
     assert_matches::assert_matches!(
         battler_service.player_data(battle.uuid, "player-1").await,
@@ -349,11 +350,12 @@ async fn plays_battle_and_finishes_and_deletes() {
         .await
         .unwrap();
 
+    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
+
     assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for battle to start.
-    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
-    assert_matches::assert_matches!(public_log_rx.recv().await, Ok(_));
+    read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "turn|turn:1").await;
 
     assert_matches::assert_matches!(
         battler_service
@@ -414,11 +416,12 @@ async fn returns_filtered_logs_by_side() {
         .await
         .unwrap();
 
+    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
+
     assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for battle to start.
-    let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
-    assert_matches::assert_matches!(public_log_rx.recv().await, Ok(_));
+    read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "turn|turn:1").await;
 
     // Read all logs from the battle starting; we only care to verify the first turn.
     while let Ok(_) = public_log_rx.try_recv() {}
@@ -798,11 +801,9 @@ async fn forfeits_on_player_timer() {
         .await
         .unwrap();
 
-    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
-
-    // Wait for battle to start.
     let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
-    assert_matches::assert_matches!(public_log_rx.recv().await, Ok(_));
+
+    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for timers to start.
     read_all_entries_from_log_rx_stopping_at(
@@ -888,9 +889,9 @@ async fn selects_random_moves_on_action_timer() {
         .await
         .unwrap();
 
-    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
-
     let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
+
+    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for turn 1.
     read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "turn|turn:1").await;
@@ -949,9 +950,9 @@ async fn only_activates_player_timer_if_request_is_active() {
         .await
         .unwrap();
 
-    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
-
     let mut public_log_rx = battler_service.subscribe(battle.uuid, None).await.unwrap();
+
+    assert_matches::assert_matches!(battler_service.start(battle.uuid).await, Ok(()));
 
     // Wait for turn 1.
     read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "turn|turn:1").await;

--- a/battler-service/tests/service_test.rs
+++ b/battler-service/tests/service_test.rs
@@ -837,11 +837,8 @@ async fn forfeits_on_player_timer() {
 
     assert_matches::assert_matches!(battler_service.full_log(battle.uuid, None).await, Ok(log) => {
         pretty_assertions::assert_eq!(
-            log[(log.len() - 9)..],
+            log[(log.len() - 6)..],
             [
-                "turn|turn:1",
-                "-battlerservice:timer|player:player-1|remainingsecs:5",
-                "-battlerservice:timer|player:player-2|remainingsecs:5",
                 "-battlerservice:timer|player:player-2|warning|remainingsecs:1",
                 "-battlerservice:timer|player:player-2|done|remainingsecs:0",
                 "continue",

--- a/battler-service/tests/service_test.rs
+++ b/battler-service/tests/service_test.rs
@@ -145,7 +145,7 @@ async fn read_all_entries_from_log_rx_stopping_at(
     log_rx: &mut broadcast::Receiver<LogEntry>,
     stop_at: &str,
 ) -> Vec<String> {
-    let deadline = SystemTime::now() + Duration::from_secs(10);
+    let deadline = SystemTime::now() + Duration::from_secs(30);
     let mut entries = Vec::new();
     loop {
         tokio::select! {
@@ -938,7 +938,7 @@ async fn only_activates_player_timer_if_request_is_active() {
             BattleServiceOptions {
                 timers: Timers {
                     player: Some(Timer {
-                        secs: 5,
+                        secs: 10,
                         warnings: BTreeSet::default(),
                     }),
                     ..Default::default()
@@ -962,7 +962,7 @@ async fn only_activates_player_timer_if_request_is_active() {
     // Wait for the timers to start to avoid the race condition.
     read_all_entries_from_log_rx_stopping_at(
         &mut public_log_rx,
-        "-battlerservice:timer|player:player-2|remainingsecs:5",
+        "-battlerservice:timer|player:player-2|remainingsecs:10",
     )
     .await;
 
@@ -984,17 +984,23 @@ async fn only_activates_player_timer_if_request_is_active() {
     // Wait for battle to end.
     let log = read_all_entries_from_log_rx_stopping_at(&mut public_log_rx, "win|side:0").await;
 
-    pretty_assertions::assert_eq!(
-        log,
-        [
-            "move|mon:Bulbasaur,player-1,1|name:Tackle|target:Bulbasaur,player-2,1",
-            "damage|mon:Bulbasaur,player-2,1|health:0",
-            "faint|mon:Bulbasaur,player-2,1",
-            "residual",
-            "-battlerservice:timer|player:player-2|remainingsecs:4",
-            "-battlerservice:timer|player:player-2|done|remainingsecs:0",
-            "continue",
-            "forfeited|player:player-2",
-        ]
+    assert_eq!(log.len(), 8);
+    assert_eq!(
+        log[0],
+        "move|mon:Bulbasaur,player-1,1|name:Tackle|target:Bulbasaur,player-2,1"
     );
+    assert_eq!(log[1], "damage|mon:Bulbasaur,player-2,1|health:0");
+    assert_eq!(log[2], "faint|mon:Bulbasaur,player-2,1");
+    assert_eq!(log[3], "residual");
+    assert!(
+        log[4].starts_with("-battlerservice:timer|player:player-2|remainingsecs:"),
+        "expected timer log with remaining seconds, got: {}",
+        log[4]
+    );
+    assert_eq!(
+        log[5],
+        "-battlerservice:timer|player:player-2|done|remainingsecs:0"
+    );
+    assert_eq!(log[6], "continue");
+    assert_eq!(log[7], "forfeited|player:player-2");
 }

--- a/battler-wamp/Cargo.toml
+++ b/battler-wamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battler-wamp"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "Asynchronous library for WAMP messaging."
 authors = ["Jackson Nestelroad <jackson@nestelroad.com>"]

--- a/battler-wamp/src/core/service.rs
+++ b/battler-wamp/src/core/service.rs
@@ -86,10 +86,10 @@ pub struct Service {
 impl Service {
     /// Creates a new service over a message stream.
     pub fn new(name: String, stream: Box<dyn MessageStream>) -> Self {
-        let (message_tx, _) = broadcast::channel(16);
+        let (message_tx, _) = broadcast::channel(48);
         let (end_tx, end_rx) = broadcast::channel(1);
         let (cancel_tx, cancel_rx) = broadcast::channel(1);
-        let (user_message_tx, user_message_rx) = mpsc::channel(16);
+        let (user_message_tx, user_message_rx) = mpsc::channel(48);
         Self {
             name,
             stream,

--- a/battler-wamp/src/core/service.rs
+++ b/battler-wamp/src/core/service.rs
@@ -196,7 +196,11 @@ impl Service {
 
     async fn end(&mut self) -> Result<()> {
         // Ignore error with the stream, since it may already be closed.
-        self.stream.close().await.ok();
+        // Set a short timeout on the close handshake to prevent deadlocks if the peer is
+        // dead/unresponsive.
+        tokio::time::timeout(Duration::from_millis(500), self.stream.close())
+            .await
+            .ok();
         self.end_tx.send(())?;
         Ok(())
     }

--- a/battler-wamp/src/core/stream.rs
+++ b/battler-wamp/src/core/stream.rs
@@ -146,7 +146,10 @@ pub struct DirectMessageStream {
 
 impl DirectMessageStream {
     /// Creates a direct message stream.
-    pub fn new(message_tx: mpsc::Sender<Message>, message_rx: mpsc::Receiver<Message>) -> Self {
+    pub fn new(
+        message_tx: mpsc::UnboundedSender<Message>,
+        message_rx: mpsc::UnboundedReceiver<Message>,
+    ) -> Self {
         let stream = futures_util::stream::unfold(message_rx, move |mut message_rx| async {
             match message_rx.recv().await {
                 Some(message) => Some((StreamMessage::Message(message), message_rx)),
@@ -157,7 +160,7 @@ impl DirectMessageStream {
             message_tx,
             move |message_tx, message: StreamMessage| async {
                 match message {
-                    StreamMessage::Message(message) => message_tx.send(message).await?,
+                    StreamMessage::Message(message) => message_tx.send(message)?,
                     StreamMessage::Ping(_) => (),
                 }
                 Ok::<_, mpsc::error::SendError<_>>(message_tx)

--- a/battler-wamp/src/peer/peer.rs
+++ b/battler-wamp/src/peer/peer.rs
@@ -920,18 +920,18 @@ where
 
     /// Disconnects from the router.
     pub async fn disconnect(&self) -> Result<()> {
-        let mut peer_state = self.peer_state.lock().await;
+        let service = {
+            let mut peer_state = self.peer_state.lock().await;
+            peer_state.take().map(|state| state.service)
+        };
 
-        match peer_state.take() {
-            Some(peer_state) => {
-                info!(
-                    "Peer {} was instructed to disconnect from the router",
-                    self.config.name
-                );
-                peer_state.service.cancel()?;
-                peer_state.service.join().await?;
-            }
-            None => (),
+        if let Some(service) = service {
+            info!(
+                "Peer {} was instructed to disconnect from the router",
+                self.config.name
+            );
+            service.cancel()?;
+            service.join().await?;
         }
         Ok(())
     }

--- a/battler-wamp/src/peer/peer.rs
+++ b/battler-wamp/src/peer/peer.rs
@@ -453,8 +453,8 @@ where
         transport_factory: Box<dyn TransportFactory<S>>,
     ) -> Result<Self> {
         config.validate()?;
-        let (session_finished_tx, _) = broadcast::channel(16);
-        let (connection_finished_tx, _) = broadcast::channel(16);
+        let (session_finished_tx, _) = broadcast::channel(48);
+        let (connection_finished_tx, _) = broadcast::channel(48);
         let (drop_tx, _) = broadcast::channel(1);
         let (end_active_connection_tx, _) = broadcast::channel(1);
         Ok(Self {
@@ -527,7 +527,7 @@ where
 
         // Start the service and message handler.
         let service = Service::new(self.config.name.clone(), stream);
-        let (message_tx, message_rx) = mpsc::channel(16);
+        let (message_tx, message_rx) = mpsc::channel(48);
         let service_message_rx = service.message_rx();
         let end_rx = service.end_rx();
         let drop_rx = self.drop_tx.subscribe();
@@ -1336,8 +1336,8 @@ where
             .await?;
 
         let session_finished_rx = self.session_finished_rx();
-        let (rpc_result_tx, rpc_result_rx) = mpsc::channel(16);
-        let (cancel_tx, cancel_rx) = mpsc::channel(16);
+        let (rpc_result_tx, rpc_result_rx) = mpsc::channel(48);
+        let (cancel_tx, cancel_rx) = mpsc::channel(48);
         let results_join_handle = tokio::spawn(Self::wait_for_results(
             request_id,
             session_rpc_result_rx,

--- a/battler-wamp/src/peer/peer.rs
+++ b/battler-wamp/src/peer/peer.rs
@@ -475,7 +475,8 @@ where
         self.session_finished_tx.subscribe()
     }
 
-    fn connection_finished_rx(&self) -> broadcast::Receiver<()> {
+    /// Receiver channel for the entire connection finishing.
+    pub fn connection_finished_rx(&self) -> broadcast::Receiver<()> {
         self.connection_finished_tx.subscribe()
     }
 

--- a/battler-wamp/src/peer/session.rs
+++ b/battler-wamp/src/peer/session.rs
@@ -499,12 +499,12 @@ impl Session {
         let (established_session_tx, _) = broadcast::channel(16);
         let (closed_session_tx, _) = broadcast::channel(16);
         let (auth_challenge_tx, _) = broadcast::channel(16);
-        let (subscribed_tx, _) = broadcast::channel(16);
-        let (unsubscribed_tx, _) = broadcast::channel(16);
-        let (published_tx, _) = broadcast::channel(16);
-        let (registered_tx, _) = broadcast::channel(16);
-        let (unregistered_tx, _) = broadcast::channel(16);
-        let (rpc_result_tx, _) = broadcast::channel(16);
+        let (subscribed_tx, _) = broadcast::channel(128);
+        let (unsubscribed_tx, _) = broadcast::channel(128);
+        let (published_tx, _) = broadcast::channel(128);
+        let (registered_tx, _) = broadcast::channel(128);
+        let (unregistered_tx, _) = broadcast::channel(128);
+        let (rpc_result_tx, _) = broadcast::channel(128);
         Self {
             name,
             service_message_tx,
@@ -818,7 +818,7 @@ impl Session {
                 Ok(())
             }
             Message::Subscribed(message) => {
-                let (event_tx, event_rx) = broadcast::channel(16);
+                let (event_tx, event_rx) = broadcast::channel(1024);
                 self.modify_established_session_state(|state| {
                     state
                         .subscriptions
@@ -882,7 +882,7 @@ impl Session {
                 Ok(())
             }
             Message::Registered(message) => {
-                let (procedure_tx, procedure_message_rx) = broadcast::channel(16);
+                let (procedure_tx, procedure_message_rx) = broadcast::channel(1024);
                 self.modify_established_session_state(|state| {
                     state
                         .procedures

--- a/battler-wamp/src/peer/session.rs
+++ b/battler-wamp/src/peer/session.rs
@@ -496,9 +496,9 @@ impl Session {
     /// Creates a new session over a service.
     pub fn new(name: String, service_message_tx: mpsc::Sender<Message>) -> Self {
         let id_allocator = SequentialIdAllocator::default();
-        let (established_session_tx, _) = broadcast::channel(16);
-        let (closed_session_tx, _) = broadcast::channel(16);
-        let (auth_challenge_tx, _) = broadcast::channel(16);
+        let (established_session_tx, _) = broadcast::channel(48);
+        let (closed_session_tx, _) = broadcast::channel(48);
+        let (auth_challenge_tx, _) = broadcast::channel(48);
         let (subscribed_tx, _) = broadcast::channel(128);
         let (unsubscribed_tx, _) = broadcast::channel(128);
         let (published_tx, _) = broadcast::channel(128);

--- a/battler-wamp/src/peer/session.rs
+++ b/battler-wamp/src/peer/session.rs
@@ -77,6 +77,8 @@ struct EstablishedSessionState {
     subscriptions: HashMap<Id, Subscription>,
     procedures: HashMap<Id, Procedure>,
     active_invocations: HashMap<Id, Id>,
+    pending_unsubscriptions: HashMap<Id, Id>,
+    pending_unregistrations: HashMap<Id, Id>,
 }
 
 impl Debug for EstablishedSessionState {
@@ -642,14 +644,18 @@ impl Session {
             }
             Message::Unsubscribe(message) => {
                 self.modify_established_session_state(|state| {
-                    state.subscriptions.remove(&message.subscribed_subscription)
+                    state
+                        .pending_unsubscriptions
+                        .insert(message.request, message.subscribed_subscription)
                 })
                 .await?;
                 Ok(())
             }
             Message::Unregister(message) => {
                 self.modify_established_session_state(|state| {
-                    state.procedures.remove(&message.registered_registration)
+                    state
+                        .pending_unregistrations
+                        .insert(message.request, message.registered_registration)
                 })
                 .await?;
                 Ok(())
@@ -730,6 +736,8 @@ impl Session {
                     subscriptions: HashMap::default(),
                     procedures: HashMap::default(),
                     active_invocations: HashMap::default(),
+                    pending_unsubscriptions: HashMap::default(),
+                    pending_unregistrations: HashMap::default(),
                 }))
                 .await
             }
@@ -775,6 +783,10 @@ impl Session {
                         self.subscribed_tx.send(Err(message.try_into()?))?;
                     }
                     Message::UNSUBSCRIBE_TAG => {
+                        self.modify_established_session_state(|state| {
+                            state.pending_unsubscriptions.remove(&error_message.request);
+                        })
+                        .await?;
                         self.unsubscribed_tx.send(Err(message.try_into()?))?;
                     }
                     Message::PUBLISH_TAG => {
@@ -784,7 +796,11 @@ impl Session {
                         self.registered_tx.send(Err(message.try_into()?))?;
                     }
                     Message::UNREGISTER_TAG => {
-                        self.registered_tx.send(Err(message.try_into()?))?;
+                        self.modify_established_session_state(|state| {
+                            state.pending_unregistrations.remove(&error_message.request);
+                        })
+                        .await?;
+                        self.unregistered_tx.send(Err(message.try_into()?))?;
                     }
                     Message::CALL_TAG => {
                         self.rpc_result_tx.send(Err(message.try_into()?))?;
@@ -818,6 +834,15 @@ impl Session {
                 Ok(())
             }
             Message::Unsubscribed(message) => {
+                self.modify_established_session_state(|state| {
+                    if let Some(sub_id) = state
+                        .pending_unsubscriptions
+                        .remove(&message.unsubscribe_request)
+                    {
+                        state.subscriptions.remove(&sub_id);
+                    }
+                })
+                .await?;
                 self.unsubscribed_tx
                     .send(Ok(peer_session_message::Unsubscription {
                         request_id: message.unsubscribe_request,
@@ -873,6 +898,15 @@ impl Session {
                 Ok(())
             }
             Message::Unregistered(message) => {
+                self.modify_established_session_state(|state| {
+                    if let Some(reg_id) = state
+                        .pending_unregistrations
+                        .remove(&message.unregister_request)
+                    {
+                        state.procedures.remove(&reg_id);
+                    }
+                })
+                .await?;
                 self.unregistered_tx
                     .send(Ok(peer_session_message::Unregistration {
                         request_id: message.unregister_request,

--- a/battler-wamp/src/router/connection.rs
+++ b/battler-wamp/src/router/connection.rs
@@ -317,7 +317,7 @@ impl Connection {
     ) -> Result<bool> {
         let mut finish_on_close = false;
         let mut router_end_rx = context.router().end_rx();
-        let (handle_message_result_tx, mut handle_message_result_rx) = mpsc::channel(16);
+        let (handle_message_result_tx, mut handle_message_result_rx) = mpsc::channel(48);
 
         // Start two separate loops for ordering guarantees of PUBLISH and CALL messages.
         tokio::spawn(Self::publish_loop(

--- a/battler-wamp/src/router/connection.rs
+++ b/battler-wamp/src/router/connection.rs
@@ -7,6 +7,7 @@ use anyhow::{
 use log::{
     error,
     info,
+    warn,
 };
 use tokio::sync::{
     broadcast::{
@@ -211,7 +212,17 @@ impl Connection {
             tokio::select! {
                 // Received a publish message.
                 publish_message = publish_rx.recv() => {
-                    session.handle_ordered_publish(&context, publish_message?).await?;
+                    match publish_message {
+                        Ok(msg) => {
+                            session.handle_ordered_publish(&context, msg).await?;
+                        }
+                        Err(RecvError::Lagged(skipped)) => {
+                            warn!("Session {} lagged by {} publications", session.id(), skipped);
+                        }
+                        Err(RecvError::Closed) => {
+                            break;
+                        }
+                    }
                 }
                 // The session loop is done, so we should also be done.
                 _ = session_loop_done_rx.recv() => {
@@ -262,17 +273,27 @@ impl Connection {
             tokio::select! {
                 // Received an ordered message.
                 message = procedure_message_rx.recv() => {
-                    match message? {
-                        ProcedureMessage::Call(call_message) => {
-                            let call_request_id = match session.handle_ordered_call(&context, call_message).await? {
-                                Some(call_request_id) => call_request_id,
-                                None => continue,
-                            };
-                            // Handle the invocation asynchronously.
-                            tokio::spawn(Self::handle_invocation(context.clone(), session.clone(), call_request_id, handle_message_result_tx.clone()));
-                        },
-                        ProcedureMessage::Cancel(cancel_message) => {
-                            session.handle_ordered_cancel(&context, cancel_message).await?;
+                    match message {
+                        Ok(msg) => {
+                            match msg {
+                                ProcedureMessage::Call(call_message) => {
+                                    let call_request_id = match session.handle_ordered_call(&context, call_message).await? {
+                                        Some(call_request_id) => call_request_id,
+                                        None => continue,
+                                    };
+                                    // Handle the invocation asynchronously.
+                                    tokio::spawn(Self::handle_invocation(context.clone(), session.clone(), call_request_id, handle_message_result_tx.clone()));
+                                },
+                                ProcedureMessage::Cancel(cancel_message) => {
+                                    session.handle_ordered_cancel(&context, cancel_message).await?;
+                                }
+                            }
+                        }
+                        Err(RecvError::Lagged(skipped)) => {
+                            warn!("Session {} lagged by {} procedure messages", session.id(), skipped);
+                        }
+                        Err(RecvError::Closed) => {
+                            break;
                         }
                     }
                 }

--- a/battler-wamp/src/router/connection.rs
+++ b/battler-wamp/src/router/connection.rs
@@ -112,7 +112,7 @@ impl Connection {
         end_rx: broadcast::Receiver<()>,
     ) -> bool {
         let session_id = context.router().id_allocator.generate_id().await;
-        let (message_tx, message_rx) = mpsc::channel(16);
+        let (message_tx, message_rx) = mpsc::unbounded_channel();
         let session = Session::new(session_id, connection_type, message_tx, service_message_tx);
 
         info!(
@@ -128,7 +128,7 @@ impl Connection {
         &self,
         context: &RouterContext<S>,
         session: Session,
-        message_rx: mpsc::Receiver<Message>,
+        message_rx: mpsc::UnboundedReceiver<Message>,
         service_message_rx: &mut broadcast::Receiver<Message>,
         end_rx: broadcast::Receiver<()>,
     ) -> bool {
@@ -310,7 +310,7 @@ impl Connection {
         &self,
         context: &RouterContext<S>,
         session: Arc<Session>,
-        mut message_rx: mpsc::Receiver<Message>,
+        mut message_rx: mpsc::UnboundedReceiver<Message>,
         service_message_rx: &mut broadcast::Receiver<Message>,
         mut end_rx: broadcast::Receiver<()>,
         session_loop_done_rx: broadcast::Receiver<()>,

--- a/battler-wamp/src/router/procedure.rs
+++ b/battler-wamp/src/router/procedure.rs
@@ -140,6 +140,21 @@ impl Procedure {
         Ok(())
     }
 
+    /// Removes a callee from the procedure registration.
+    ///
+    /// Returns the number of remaining callees.
+    async fn remove_callee(&self, callee: Id) -> usize {
+        let mut registration = self.registration.lock().await;
+        registration.callees.retain(|c| c.session != callee);
+        if registration.callees.is_empty() {
+            0
+        } else {
+            registration.last_callee_index =
+                registration.last_callee_index % registration.callees.len();
+            registration.callees.len()
+        }
+    }
+
     /// The caller's identity should be disclosed to the callee.
     pub fn disclose_caller(&self) -> bool {
         self.options.disclose_caller
@@ -295,14 +310,26 @@ impl ProcedureManager {
     }
 
     /// Deregisters a procedure.
-    pub async fn unregister<S>(context: &RealmContext<'_, S>, procedure: &WildcardUri) {
-        context
-            .realm()
-            .procedure_manager
-            .procedures
-            .write()
-            .await
-            .remove(procedure.split());
+    pub async fn unregister<S>(
+        context: &RealmContext<'_, S>,
+        session: Id,
+        procedure: &WildcardUri,
+    ) {
+        let remove = if let Some(p) = Self::get(context, procedure).await {
+            p.remove_callee(session).await == 0
+        } else {
+            false
+        };
+
+        if remove {
+            context
+                .realm()
+                .procedure_manager
+                .procedures
+                .write()
+                .await
+                .remove(procedure.split());
+        }
     }
 
     /// Gets the procedure matching the URI.

--- a/battler-wamp/src/router/procedure.rs
+++ b/battler-wamp/src/router/procedure.rs
@@ -277,10 +277,21 @@ impl ProcedureManager {
     ///
     /// Required for proper ordering of messages. The procedure should not receive invocations until
     /// after the peer has received the registration confirmation.
-    pub async fn activate_procedure<S>(context: &RealmContext<'_, S>, procedure: &WildcardUri) {
+    pub async fn activate_procedure<S, F, Fut>(
+        context: &RealmContext<'_, S>,
+        procedure: &WildcardUri,
+        after_activation: F,
+    ) -> Result<()>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         if let Some(procedure) = context.procedure(procedure).await {
-            procedure.state.lock().await.active = true;
+            let mut state = procedure.state.lock().await;
+            state.active = true;
+            after_activation().await?;
         }
+        Ok(())
     }
 
     /// Deregisters a procedure.

--- a/battler-wamp/src/router/procedure.rs
+++ b/battler-wamp/src/router/procedure.rs
@@ -315,20 +315,16 @@ impl ProcedureManager {
         session: Id,
         procedure: &WildcardUri,
     ) {
-        let remove = if let Some(p) = Self::get(context, procedure).await {
+        let mut procedures = context.realm().procedure_manager.procedures.write().await;
+
+        let remove = if let Some(p) = procedures.find(procedure.split()) {
             p.remove_callee(session).await == 0
         } else {
             false
         };
 
         if remove {
-            context
-                .realm()
-                .procedure_manager
-                .procedures
-                .write()
-                .await
-                .remove(procedure.split());
+            procedures.remove(procedure.split());
         }
     }
 

--- a/battler-wamp/src/router/router.rs
+++ b/battler-wamp/src/router/router.rs
@@ -441,8 +441,8 @@ where
     }
 
     fn direct_connect(context: &RouterContext<S>) -> DirectConnection {
-        let (router_to_peer_tx, router_to_peer_rx) = mpsc::channel(16);
-        let (peer_to_router_tx, peer_to_router_rx) = mpsc::channel(16);
+        let (router_to_peer_tx, router_to_peer_rx) = mpsc::unbounded_channel();
+        let (peer_to_router_tx, peer_to_router_rx) = mpsc::unbounded_channel();
         let router_stream = DirectMessageStream::new(router_to_peer_tx, peer_to_router_rx);
         let peer_stream = DirectMessageStream::new(peer_to_router_tx, router_to_peer_rx);
         let uuid = Self::start_connection_over_stream(context, Box::new(router_stream));

--- a/battler-wamp/src/router/router.rs
+++ b/battler-wamp/src/router/router.rs
@@ -264,7 +264,7 @@ where
         let cancel_rx = self.cancel_rx.resubscribe();
 
         let cancel_tx = self.cancel_tx.clone();
-        let (control_tx, control_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(48);
         let context = RouterContext::new(self);
         let start_handle = tokio::spawn(Self::handle_connections(
             context.clone(),

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1340,6 +1340,7 @@ impl Session {
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
 
+        debug!("TRACE: attempting to get rpc_yield_rx");
         let mut rpc_yield_rx = invocation
             .state
             .lock()
@@ -1349,6 +1350,7 @@ impl Session {
             .ok_or_else(|| {
                 BasicError::Internal("expected invocation to have a yield receiver".to_owned())
             })?;
+        debug!("TRACE: got rpc_yield_rx");
         let mut cancel_rx = self.rpc_yield_cancel_rx.resubscribe();
         let mut closed_session_rx = self.closed_session_tx.subscribe();
 
@@ -1432,6 +1434,7 @@ impl Session {
             };
             tokio::select! {
                 rpc_yield = rpc_yield_rx.recv() => {
+                    debug!("TRACE: got message out of rpc_yield_rx: {rpc_yield:?}");
                     match rpc_yield.map_err(|err| match err {
                         RecvError::Closed => Error::new(InteractionError::Canceled),
                         _ => err.into()

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -342,8 +342,8 @@ impl Session {
         let (closed_session_tx, _) = broadcast::channel(16);
         let (rpc_yield_tx, _) = broadcast::channel(16);
         let (rpc_yield_cancel_tx, rpc_yield_cancel_rx) = broadcast::channel(16);
-        let (publish_tx, _) = broadcast::channel(16);
-        let (procedure_message_tx, _) = broadcast::channel(16);
+        let (publish_tx, _) = broadcast::channel(1024);
+        let (procedure_message_tx, _) = broadcast::channel(1024);
         Self {
             id,
             connection_type,

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -224,11 +224,33 @@ struct RpcInvocationCalleeDetails {
     caller_identification: bool,
 }
 
-#[derive(Debug, Default)]
 struct RpcInvocationState {
-    current_callee: Option<RpcInvocationCalleeDetails>,
     callees_attempted: HashSet<Id>,
     canceled: bool,
+    current_callee: Option<RpcInvocationCalleeDetails>,
+    current_callee_rpc_yield_rx:
+        Option<broadcast::Receiver<ChannelTransmittableResult<router_session_message::RpcYield>>>,
+}
+
+impl Debug for RpcInvocationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcInvocationState")
+            .field("callees_attempted", &self.callees_attempted)
+            .field("canceled", &self.canceled)
+            .field("current_callee", &self.current_callee)
+            .finish()
+    }
+}
+
+impl Default for RpcInvocationState {
+    fn default() -> Self {
+        Self {
+            callees_attempted: HashSet::default(),
+            canceled: false,
+            current_callee: None,
+            current_callee_rpc_yield_rx: None,
+        }
+    }
 }
 
 /// The result of an RPC invocation.
@@ -1225,6 +1247,8 @@ impl Session {
                     callee_details.callee.session
                 ))
             })?;
+        let rpc_yield_rx = session.session.rpc_yield_rx.resubscribe();
+        invocation.state.lock().await.current_callee_rpc_yield_rx = Some(rpc_yield_rx);
         session
             .session
             .send_message(Message::Invocation(InvocationMessage {
@@ -1315,7 +1339,15 @@ impl Session {
             .session(callee_details.callee.session)
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
-        let mut rpc_yield_rx = callee.session.rpc_yield_rx.resubscribe();
+        let mut rpc_yield_rx = invocation
+            .state
+            .lock()
+            .await
+            .current_callee_rpc_yield_rx
+            .take()
+            .ok_or_else(|| {
+                BasicError::Internal("expected invocation to have a yield receiver".to_owned())
+            })?;
         let mut cancel_rx = self.rpc_yield_cancel_rx.resubscribe();
         let mut closed_session_rx = self.closed_session_tx.subscribe();
 

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1463,8 +1463,8 @@ impl Session {
                                 ..Default::default()
                             })
                         ).await?;
-                        return Err(InteractionError::Canceled.into());
                     }
+                    return Err(InteractionError::Canceled.into());
                 }
                 _ = timeout => {
                     // Dealer-initiated timeout: interrupt the callee (if supported) and error out immediately.

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -943,8 +943,8 @@ impl Session {
         })
         .await?;
         // Activate the procedure and send confirmation while holding the procedure state lock.
-        // This guarantees that the client receives the REGISTERED confirmation before any concurrent
-        // invocations can be routed and queued on this session.
+        // This guarantees that the client receives the REGISTERED confirmation before any
+        // concurrent invocations can be routed and queued on this session.
         ProcedureManager::activate_procedure(&context, &message.procedure, || async {
             self.send_message(Message::Registered(RegisteredMessage {
                 register_request: message.request,

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1340,8 +1340,6 @@ impl Session {
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
 
-        tokio::task::yield_now().await;
-
         let mut rpc_yield_rx = invocation
             .state
             .lock()

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1340,7 +1340,6 @@ impl Session {
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
 
-        debug!("jnestelroad: attempting to get rpc_yield_rx");
         let mut rpc_yield_rx = invocation
             .state
             .lock()
@@ -1350,7 +1349,6 @@ impl Session {
             .ok_or_else(|| {
                 BasicError::Internal("expected invocation to have a yield receiver".to_owned())
             })?;
-        debug!("jnestelroad: got rpc_yield_rx");
         let mut cancel_rx = self.rpc_yield_cancel_rx.resubscribe();
         let mut closed_session_rx = self.closed_session_tx.subscribe();
 
@@ -1434,7 +1432,6 @@ impl Session {
             };
             tokio::select! {
                 rpc_yield = rpc_yield_rx.recv() => {
-                    debug!("jnestelroad: got message out of rpc_yield_rx: {rpc_yield:?}");
                     match rpc_yield.map_err(|err| match err {
                         RecvError::Closed => Error::new(InteractionError::Canceled),
                         _ => err.into()

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1339,6 +1339,9 @@ impl Session {
             .session(callee_details.callee.session)
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
+
+        tokio::task::yield_now().await;
+
         let mut rpc_yield_rx = invocation
             .state
             .lock()

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -360,9 +360,9 @@ impl Session {
         service_message_tx: mpsc::Sender<Message>,
     ) -> Self {
         let id_allocator = SequentialIdAllocator::default();
-        let (closed_session_tx, _) = broadcast::channel(16);
-        let (rpc_yield_tx, _) = broadcast::channel(16);
-        let (rpc_yield_cancel_tx, rpc_yield_cancel_rx) = broadcast::channel(16);
+        let (closed_session_tx, _) = broadcast::channel(48);
+        let (rpc_yield_tx, _) = broadcast::channel(48);
+        let (rpc_yield_cancel_tx, rpc_yield_cancel_rx) = broadcast::channel(48);
         let (publish_tx, _) = broadcast::channel(1024);
         let (procedure_message_tx, _) = broadcast::channel(1024);
         Self {

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -806,14 +806,17 @@ impl Session {
                 .insert(subscription, message.topic.clone())
         })
         .await?;
-        self.send_message(Message::Subscribed(SubscribedMessage {
-            subscribe_request: message.request,
-            subscription,
-        }))
+        // Activate the subscription and send confirmation while holding the subscription lock.
+        // This guarantees that the client receives the SUBSCRIBED confirmation before any matching
+        // concurrent publisher events can be routed and queued on this session.
+        TopicManager::activate_subscription(&context, self.id, &message.topic, || async {
+            self.send_message(Message::Subscribed(SubscribedMessage {
+                subscribe_request: message.request,
+                subscription,
+            }))
+            .await
+        })
         .await?;
-        // Activate the subscription only after sending the response, so that the peer does not
-        // receive events prior to the confirmation.
-        TopicManager::activate_subscription(&context, self.id, &message.topic).await;
         Ok(())
     }
 
@@ -939,14 +942,17 @@ impl Session {
                 .insert(registration, message.procedure.clone())
         })
         .await?;
-        self.send_message(Message::Registered(RegisteredMessage {
-            register_request: message.request,
-            registration,
-        }))
+        // Activate the procedure and send confirmation while holding the procedure state lock.
+        // This guarantees that the client receives the REGISTERED confirmation before any concurrent
+        // invocations can be routed and queued on this session.
+        ProcedureManager::activate_procedure(&context, &message.procedure, || async {
+            self.send_message(Message::Registered(RegisteredMessage {
+                register_request: message.request,
+                registration,
+            }))
+            .await
+        })
         .await?;
-        // Activate the procedure only after sending the response, so that the peer does not
-        // receive invocations prior to the confirmation.
-        ProcedureManager::activate_procedure(&mut context, &message.procedure).await;
         Ok(())
     }
 

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -994,7 +994,7 @@ impl Session {
             .get_from_established_session_state(|state| state.realm.clone())
             .await?;
         let mut context = context.realm_context(&realm)?;
-        ProcedureManager::unregister(&mut context, &procedure).await;
+        ProcedureManager::unregister(&mut context, self.id, &procedure).await;
         self.send_message(Message::Unregistered(UnregisteredMessage {
             unregister_request: message.request,
         }))
@@ -1656,7 +1656,7 @@ impl Session {
                 state.subscriptions.clear();
 
                 for procedure in state.procedures.values() {
-                    ProcedureManager::unregister(&mut context, &procedure).await;
+                    ProcedureManager::unregister(&mut context, id, &procedure).await;
                 }
                 state.procedures.clear();
 

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -1340,7 +1340,7 @@ impl Session {
             .await
             .ok_or_else(|| Error::new(InteractionError::Canceled))?;
 
-        debug!("TRACE: attempting to get rpc_yield_rx");
+        debug!("jnestelroad: attempting to get rpc_yield_rx");
         let mut rpc_yield_rx = invocation
             .state
             .lock()
@@ -1350,7 +1350,7 @@ impl Session {
             .ok_or_else(|| {
                 BasicError::Internal("expected invocation to have a yield receiver".to_owned())
             })?;
-        debug!("TRACE: got rpc_yield_rx");
+        debug!("jnestelroad: got rpc_yield_rx");
         let mut cancel_rx = self.rpc_yield_cancel_rx.resubscribe();
         let mut closed_session_rx = self.closed_session_tx.subscribe();
 
@@ -1434,7 +1434,7 @@ impl Session {
             };
             tokio::select! {
                 rpc_yield = rpc_yield_rx.recv() => {
-                    debug!("TRACE: got message out of rpc_yield_rx: {rpc_yield:?}");
+                    debug!("jnestelroad: got message out of rpc_yield_rx: {rpc_yield:?}");
                     match rpc_yield.map_err(|err| match err {
                         RecvError::Closed => Error::new(InteractionError::Canceled),
                         _ => err.into()

--- a/battler-wamp/src/router/session.rs
+++ b/battler-wamp/src/router/session.rs
@@ -256,7 +256,7 @@ pub struct SessionHandle {
     id: Id,
     shared_state: Arc<RwLock<SharedSessionState>>,
     id_allocator: Arc<Box<dyn IdAllocator>>,
-    message_tx: mpsc::Sender<Message>,
+    message_tx: mpsc::UnboundedSender<Message>,
 
     closed_session_rx: broadcast::Receiver<()>,
     rpc_yield_rx: broadcast::Receiver<ChannelTransmittableResult<router_session_message::RpcYield>>,
@@ -286,14 +286,13 @@ impl SessionHandle {
 
     /// Sends a message over the session.
     pub async fn send_message(&self, message: Message) -> Result<()> {
-        self.message_tx.send(message).await.map_err(Error::new)
+        self.message_tx.send(message).map_err(Error::new)
     }
 
     /// Closes the session.
     pub async fn close(&self, close_reason: CloseReason) -> Result<()> {
         self.message_tx
             .send(goodbye_with_close_reason(close_reason))
-            .await
             .map_err(Error::new)
     }
 
@@ -314,7 +313,7 @@ impl SessionHandle {
 pub struct Session {
     id: Id,
     connection_type: ConnectionType,
-    message_tx: mpsc::Sender<Message>,
+    message_tx: mpsc::UnboundedSender<Message>,
     service_message_tx: mpsc::Sender<Message>,
     state: RwLock<SessionState>,
     shared_state: Arc<RwLock<SharedSessionState>>,
@@ -335,7 +334,7 @@ impl Session {
     pub fn new(
         id: Id,
         connection_type: ConnectionType,
-        message_tx: mpsc::Sender<Message>,
+        message_tx: mpsc::UnboundedSender<Message>,
         service_message_tx: mpsc::Sender<Message>,
     ) -> Self {
         let id_allocator = SequentialIdAllocator::default();

--- a/battler-wamp/src/router/topic.rs
+++ b/battler-wamp/src/router/topic.rs
@@ -172,16 +172,24 @@ impl TopicManager {
     ///
     /// Required for proper ordering of events. The subscription should not receive events until
     /// after the peer has received the subscription confirmation.
-    pub async fn activate_subscription<S>(
+    pub async fn activate_subscription<S, F, Fut>(
         context: &RealmContext<'_, S>,
         session: Id,
         topic: &WildcardUri,
-    ) {
+        after_activation: F,
+    ) -> Result<()>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         if let Some(topic) = context.topic(topic).await {
-            if let Some(subscriber) = topic.subscribers.write().await.get_mut(&session) {
+            let mut subscribers = topic.subscribers.write().await;
+            if let Some(subscriber) = subscribers.get_mut(&session) {
                 subscriber.active = true;
+                after_activation().await?;
             }
         }
+        Ok(())
     }
 
     /// Unsubscribes from a topic.

--- a/battler-wamp/tests/connection_test.rs
+++ b/battler-wamp/tests/connection_test.rs
@@ -47,6 +47,7 @@ async fn peer_connects_to_router() {
 
     let (router_handle, router_join_handle) = start_router().await.unwrap();
     let peer = create_peer().unwrap();
+    let mut connection_finished_rx = peer.connection_finished_rx();
 
     // Connect to the router.
     assert_matches::assert_matches!(
@@ -61,6 +62,8 @@ async fn peer_connects_to_router() {
     // untracked connection not attached to any realm.
     router_handle.cancel().unwrap();
     router_join_handle.await.unwrap();
+
+    connection_finished_rx.recv().await.unwrap();
 
     // The peer is not connected.
     assert_matches::assert_matches!(peer.join_realm(REALM).await, Err(err) => {

--- a/battler-wamp/tests/pub_sub_test.rs
+++ b/battler-wamp/tests/pub_sub_test.rs
@@ -1242,7 +1242,7 @@ mod subscription_wildcard_match_test {
         );
         assert_matches::assert_matches!(subscriber.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             subscribe_that_expects_no_event(
                 &subscriber,
@@ -1365,7 +1365,7 @@ mod subscription_wildcard_match_test {
         );
         assert_matches::assert_matches!(subscriber.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             subscribe_that_expects_no_event(
                 &subscriber,

--- a/battler-wamp/tests/pub_sub_test.rs
+++ b/battler-wamp/tests/pub_sub_test.rs
@@ -1123,12 +1123,7 @@ mod subscription_wildcard_match_test {
             .unwrap();
 
         async fn handler(mut subscription: Subscription) {
-            loop {
-                match subscription.event_rx.recv().await {
-                    Ok(_) => return,
-                    _ => (),
-                }
-            }
+            subscription.event_rx.recv().await.unwrap();
         }
 
         tokio::spawn(handler(subscription))
@@ -1156,7 +1151,9 @@ mod subscription_wildcard_match_test {
                             Ok(_) => {
                                 panic!("unexpected event {event:?}");
                             }
-                            _ => (),
+                            Err(_) => {
+                                return;
+                            }
                         }
                     }
                     _ = cancel_rx.recv() => {

--- a/battler-wamp/tests/pub_sub_test.rs
+++ b/battler-wamp/tests/pub_sub_test.rs
@@ -887,7 +887,6 @@ async fn publish_matches_subscription_by_prefix() {
         Ok(())
     );
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
     assert_matches::assert_matches!(subscriber.unsubscribe(subscription.id).await, Ok(()));
 
     let mut topics_seen = Vec::default();
@@ -987,7 +986,6 @@ async fn publish_matches_subscription_by_wildcard() {
         Ok(())
     );
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
     assert_matches::assert_matches!(subscriber.unsubscribe(subscription.id).await, Ok(()));
 
     let mut topics_seen = Vec::default();
@@ -1067,7 +1065,6 @@ async fn publish_matches_subscription_by_wildcard_prefix() {
         Ok(())
     );
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
     assert_matches::assert_matches!(subscriber.unsubscribe(subscription.id).await, Ok(()));
 
     let mut topics_seen = Vec::default();
@@ -1116,7 +1113,6 @@ mod subscription_wildcard_match_test {
         peer: &Peer<S>,
         uri: WildcardUri,
         match_style: Option<MatchStyle>,
-        cancel_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<()>
     where
         S: Send + 'static,
@@ -1126,29 +1122,16 @@ mod subscription_wildcard_match_test {
             .await
             .unwrap();
 
-        async fn handler(
-            mut subscription: Subscription,
-            uri: WildcardUri,
-            mut cancel_rx: broadcast::Receiver<()>,
-        ) {
+        async fn handler(mut subscription: Subscription) {
             loop {
-                tokio::select! {
-                    event = subscription.event_rx.recv() => {
-                        match event {
-                            Ok(_) => {
-                                return;
-                            }
-                            _ => (),
-                        }
-                    }
-                    _ = cancel_rx.recv() => {
-                        panic!("no event received for {uri}");
-                    }
+                match subscription.event_rx.recv().await {
+                    Ok(_) => return,
+                    _ => (),
                 }
             }
         }
 
-        tokio::spawn(handler(subscription, uri, cancel_rx))
+        tokio::spawn(handler(subscription))
     }
 
     async fn subscribe_that_expects_no_event<S>(
@@ -1210,12 +1193,10 @@ mod subscription_wildcard_match_test {
         );
         assert_matches::assert_matches!(subscriber.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
         let handles = Vec::from_iter([subscribe_that_expects_event(
             &subscriber,
             WildcardUri::try_from("a1.b2.c3.d4.e55").unwrap(),
             None,
-            cancel_rx.resubscribe(),
         )
         .await]);
 
@@ -1229,10 +1210,13 @@ mod subscription_wildcard_match_test {
             Ok(_)
         );
 
-        // A small delay to ensure published events are received by the peer.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        cancel_tx.send(()).unwrap();
-        for result in futures_util::future::join_all(handles).await {
+        let results = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures_util::future::join_all(handles),
+        )
+        .await
+        .unwrap();
+        for result in results {
             assert_matches::assert_matches!(result, Ok(()));
         }
     }
@@ -1274,7 +1258,6 @@ mod subscription_wildcard_match_test {
                 &subscriber,
                 WildcardUri::try_from("a1.b2.c3").unwrap(),
                 Some(MatchStyle::Prefix),
-                cancel_rx.resubscribe(),
             )
             .await,
         ]);
@@ -1289,10 +1272,14 @@ mod subscription_wildcard_match_test {
             Ok(_)
         );
 
-        // A small delay to ensure published events are received by the peer.
-        tokio::time::sleep(Duration::from_millis(200)).await;
         cancel_tx.send(()).unwrap();
-        for result in futures_util::future::join_all(handles).await {
+        let results = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures_util::future::join_all(handles),
+        )
+        .await
+        .unwrap();
+        for result in results {
             assert_matches::assert_matches!(result, Ok(()));
         }
     }
@@ -1321,20 +1308,17 @@ mod subscription_wildcard_match_test {
         );
         assert_matches::assert_matches!(subscriber.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
         let handles = Vec::from_iter([
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1.b2.c3").unwrap(),
                 Some(MatchStyle::Prefix),
-                cancel_rx.resubscribe(),
             )
             .await,
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1.b2.c3.d4").unwrap(),
                 Some(MatchStyle::Prefix),
-                cancel_rx.resubscribe(),
             )
             .await,
         ]);
@@ -1349,10 +1333,13 @@ mod subscription_wildcard_match_test {
             Ok(_)
         );
 
-        // A small delay to ensure published events are received by the peer.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        cancel_tx.send(()).unwrap();
-        for result in futures_util::future::join_all(handles).await {
+        let results = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures_util::future::join_all(handles),
+        )
+        .await
+        .unwrap();
+        for result in results {
             assert_matches::assert_matches!(result, Ok(()));
         }
     }
@@ -1394,7 +1381,6 @@ mod subscription_wildcard_match_test {
                 &subscriber,
                 WildcardUri::try_from("a1.b2..d4.e5").unwrap(),
                 Some(MatchStyle::Wildcard),
-                cancel_rx.resubscribe(),
             )
             .await,
         ]);
@@ -1409,10 +1395,14 @@ mod subscription_wildcard_match_test {
             Ok(_)
         );
 
-        // A small delay to ensure published events are received by the peer.
-        tokio::time::sleep(Duration::from_millis(200)).await;
         cancel_tx.send(()).unwrap();
-        for result in futures_util::future::join_all(handles).await {
+        let results = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures_util::future::join_all(handles),
+        )
+        .await
+        .unwrap();
+        for result in results {
             assert_matches::assert_matches!(result, Ok(()));
         }
     }
@@ -1441,34 +1431,29 @@ mod subscription_wildcard_match_test {
         );
         assert_matches::assert_matches!(subscriber.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
         let handles = Vec::from_iter([
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1.b2.c3.d4.e5").unwrap(),
                 None,
-                cancel_rx.resubscribe(),
             )
             .await,
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1.b2.c3.d4").unwrap(),
                 Some(MatchStyle::Prefix),
-                cancel_rx.resubscribe(),
             )
             .await,
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1.b2..d4.e5").unwrap(),
                 Some(MatchStyle::Wildcard),
-                cancel_rx.resubscribe(),
             )
             .await,
             subscribe_that_expects_event(
                 &subscriber,
                 WildcardUri::try_from("a1....e5").unwrap(),
                 Some(MatchStyle::Wildcard),
-                cancel_rx.resubscribe(),
             )
             .await,
         ]);
@@ -1483,10 +1468,13 @@ mod subscription_wildcard_match_test {
             Ok(_)
         );
 
-        // A small delay to ensure published events are received by the peer.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        cancel_tx.send(()).unwrap();
-        for result in futures_util::future::join_all(handles).await {
+        let results = tokio::time::timeout(
+            Duration::from_secs(5),
+            futures_util::future::join_all(handles),
+        )
+        .await
+        .unwrap();
+        for result in results {
             assert_matches::assert_matches!(result, Ok(()));
         }
     }

--- a/battler-wamp/tests/rpc_test.rs
+++ b/battler-wamp/tests/rpc_test.rs
@@ -2213,10 +2213,7 @@ async fn cancellation_occurs_for_shared_registration() {
         }
     }
 
-    async fn stalling_handler(
-        mut procedure: Procedure,
-        invocation_received_tx: mpsc::Sender<()>,
-    ) {
+    async fn stalling_handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
         while let Ok(message) = procedure.procedure_message_rx.recv().await {
             match message {
                 ProcedureMessage::Invocation(_) => {
@@ -2246,10 +2243,7 @@ async fn cancellation_occurs_for_shared_registration() {
         .await
         .unwrap();
 
-    tokio::spawn(stalling_handler(
-        procedure,
-        invocation_received_tx.clone(),
-    ));
+    tokio::spawn(stalling_handler(procedure, invocation_received_tx.clone()));
 
     let rpc = caller
         .call(Uri::try_from("com.battler.fn").unwrap(), RpcCall::default())

--- a/battler-wamp/tests/rpc_test.rs
+++ b/battler-wamp/tests/rpc_test.rs
@@ -385,9 +385,9 @@ async fn peer_cancels_call_immediately() {
 
     async fn handler(mut procedure: Procedure) {
         loop {
-            if let Ok(ProcedureMessage::Interrupt(_)) = procedure.procedure_message_rx.recv().await
-            {
-                break;
+            match procedure.procedure_message_rx.recv().await.unwrap() {
+                ProcedureMessage::Interrupt(_) => break,
+                _ => (),
             }
         }
     }
@@ -1252,20 +1252,17 @@ mod procedure_wildcard_match_test {
             uri: WildcardUri,
             mut cancel_rx: broadcast::Receiver<()>,
         ) {
-            loop {
-                tokio::select! {
-                    message = procedure.procedure_message_rx.recv() => {
-                        match message {
-                            Ok(ProcedureMessage::Invocation(invocation)) => {
-                                invocation.respond_ok(RpcYield::default()).await.unwrap();
-                                return;
-                            }
-                            _ => (),
+            tokio::select! {
+                message = procedure.procedure_message_rx.recv() => {
+                    match message.unwrap() {
+                        ProcedureMessage::Invocation(invocation) => {
+                            invocation.respond_ok(RpcYield::default()).await.unwrap();
                         }
+                        _ => panic!("expected invocation"),
                     }
-                    _ = cancel_rx.recv() => {
-                        panic!("no invocation received for {uri}");
-                    }
+                }
+                _ = cancel_rx.recv() => {
+                    panic!("no invocation received for {uri}");
                 }
             }
         }
@@ -1300,6 +1297,9 @@ mod procedure_wildcard_match_test {
                         match message {
                             Ok(ProcedureMessage::Invocation(invocation)) => {
                                 panic!("unexpected invocation {invocation:?}")
+                            }
+                            Err(_) => {
+                                return;
                             }
                             _ => (),
                         }

--- a/battler-wamp/tests/rpc_test.rs
+++ b/battler-wamp/tests/rpc_test.rs
@@ -436,7 +436,7 @@ async fn peer_cancels_call_after_invocation() {
         .await
         .unwrap();
 
-    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
+    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(48);
 
     async fn handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
         let mut invocation_id = Id::MAX;
@@ -502,7 +502,7 @@ async fn peer_kills_call_and_gets_result() {
         .await
         .unwrap();
 
-    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
+    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(48);
     async fn handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
         async fn handle_invocation(invocation: Invocation, mut interrupt_rx: mpsc::Receiver<()>) {
             loop {
@@ -524,7 +524,7 @@ async fn peer_kills_call_and_gets_result() {
             match message {
                 ProcedureMessage::Invocation(invocation) => {
                     invocation_received_tx.send(()).await.unwrap();
-                    let (interrupt_tx, interrupt_rx) = mpsc::channel(16);
+                    let (interrupt_tx, interrupt_rx) = mpsc::channel(48);
                     interrupt_txs.insert(invocation.id(), interrupt_tx);
                     tokio::spawn(handle_invocation(invocation, interrupt_rx));
                 }
@@ -771,7 +771,7 @@ async fn peer_kills_progressive_call_and_ends_stream() {
         .await
         .unwrap();
 
-    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
+    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(48);
     async fn handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
         async fn handle_invocation(invocation: Invocation, mut interrupt_rx: mpsc::Receiver<()>) {
             loop {
@@ -793,7 +793,7 @@ async fn peer_kills_progressive_call_and_ends_stream() {
             match message {
                 ProcedureMessage::Invocation(invocation) => {
                     invocation_received_tx.send(()).await.unwrap();
-                    let (interrupt_tx, interrupt_rx) = mpsc::channel(16);
+                    let (interrupt_tx, interrupt_rx) = mpsc::channel(48);
                     interrupt_txs.insert(invocation.id(), interrupt_tx);
                     tokio::spawn(handle_invocation(invocation, interrupt_rx));
                 }
@@ -861,7 +861,7 @@ async fn progressive_call_interrupted_when_caller_leaves() {
 
     // Must wait for the invocation to be received, since a canceled call could never be sent to the
     // callee.
-    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
+    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(48);
 
     async fn handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
         async fn handle_invocation(invocation: Invocation) {
@@ -1338,7 +1338,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([register_handler_that_expects_invocation(
             &callee,
             WildcardUri::try_from("a1.b2.c3.d4.e55").unwrap(),
@@ -1387,7 +1387,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_no_invocation(
                 &callee,
@@ -1445,7 +1445,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_no_invocation(
                 &callee,
@@ -1503,7 +1503,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_no_invocation(
                 &callee,
@@ -1561,7 +1561,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_no_invocation(
                 &callee,
@@ -1619,7 +1619,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_invocation(
                 &callee,
@@ -1677,7 +1677,7 @@ mod procedure_wildcard_match_test {
         );
         assert_matches::assert_matches!(callee.join_realm(REALM).await, Ok(()));
 
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
         let handles = Vec::from_iter([
             register_handler_that_expects_no_invocation(
                 &callee,
@@ -2234,7 +2234,7 @@ async fn cancellation_occurs_for_shared_registration() {
         }
     }
 
-    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
+    let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(48);
     tokio::spawn(unavailable_handler(
         procedure,
         invocation_received_tx.clone(),

--- a/battler-wamp/tests/rpc_test.rs
+++ b/battler-wamp/tests/rpc_test.rs
@@ -2214,12 +2214,20 @@ async fn cancellation_occurs_for_shared_registration() {
     }
 
     async fn stalling_handler(mut procedure: Procedure, invocation_received_tx: mpsc::Sender<()>) {
+        let mut active_invocation: Option<Invocation> = None;
         while let Ok(message) = procedure.procedure_message_rx.recv().await {
             match message {
-                ProcedureMessage::Invocation(_) => {
+                ProcedureMessage::Invocation(invocation) => {
+                    active_invocation = Some(invocation);
                     invocation_received_tx.send(()).await.unwrap();
                 }
                 ProcedureMessage::Interrupt(_) => {
+                    if let Some(invocation) = active_invocation.take() {
+                        invocation
+                            .respond::<InteractionError>(Err(InteractionError::Canceled))
+                            .await
+                            .unwrap();
+                    }
                     break;
                 }
             }

--- a/battler-wamp/tests/rpc_test.rs
+++ b/battler-wamp/tests/rpc_test.rs
@@ -2213,6 +2213,22 @@ async fn cancellation_occurs_for_shared_registration() {
         }
     }
 
+    async fn stalling_handler(
+        mut procedure: Procedure,
+        invocation_received_tx: mpsc::Sender<()>,
+    ) {
+        while let Ok(message) = procedure.procedure_message_rx.recv().await {
+            match message {
+                ProcedureMessage::Invocation(_) => {
+                    invocation_received_tx.send(()).await.unwrap();
+                }
+                ProcedureMessage::Interrupt(_) => {
+                    break;
+                }
+            }
+        }
+    }
+
     let (invocation_received_tx, mut invocation_received_rx) = mpsc::channel(16);
     tokio::spawn(unavailable_handler(
         procedure,
@@ -2230,7 +2246,7 @@ async fn cancellation_occurs_for_shared_registration() {
         .await
         .unwrap();
 
-    tokio::spawn(unavailable_handler(
+    tokio::spawn(stalling_handler(
         procedure,
         invocation_received_tx.clone(),
     ));

--- a/battler-wamprat-schema/Cargo.toml
+++ b/battler-wamprat-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battler-wamprat-schema"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Procedural macro for strongly-typed WAMP peers."
 authors = ["Jackson Nestelroad <jackson@nestelroad.com>"]

--- a/battler-wamprat-schema/battler-wamprat-schema-proc-macro/tests/wamprat_schema_test.rs
+++ b/battler-wamprat-schema/battler-wamprat-schema-proc-macro/tests/wamprat_schema_test.rs
@@ -243,7 +243,7 @@ async fn generates_pub_sub_for_calculator_topics() {
     .unwrap();
     consumer.wait_until_ready().await.unwrap();
 
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         consumer.subscribe_ping(PingHandler { events_tx }).await,
         Ok(())
@@ -413,7 +413,7 @@ async fn generates_pub_sub_for_chat_topics() {
     .unwrap();
     consumer.wait_until_ready().await.unwrap();
 
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         consumer
             .subscribe_message(MessageHandler { events_tx })
@@ -526,7 +526,7 @@ async fn generates_pub_sub_for_chat_topics_for_particular_channel() {
         channel: "main".to_owned(),
     };
 
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         consumer
             .subscribe_channel_message(&pattern, MessageHandler { events_tx })

--- a/battler-wamprat-schema/src/lib.rs
+++ b/battler-wamprat-schema/src/lib.rs
@@ -331,7 +331,7 @@
 //!         }
 //!     }
 //!
-//!     let (events_tx, mut events_rx) = broadcast::channel(16);
+//!     let (events_tx, mut events_rx) = broadcast::channel(48);
 //!     assert_matches::assert_matches!(
 //!         consumer.subscribe_ping(PingHandler { events_tx }).await,
 //!         Ok(())
@@ -361,7 +361,7 @@
 //!         }
 //!     }
 //!
-//!     let (events_tx, mut events_rx) = broadcast::channel(16);
+//!     let (events_tx, mut events_rx) = broadcast::channel(48);
 //!     assert_matches::assert_matches!(
 //!         consumer
 //!             .subscribe_message(MessageHandler { events_tx })

--- a/battler-wamprat/Cargo.toml
+++ b/battler-wamprat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battler-wamprat"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Asynchronous library for strongly-typed WAMP peer messaging."
 authors = ["Jackson Nestelroad <jackson@nestelroad.com>"]

--- a/battler-wamprat/src/lib.rs
+++ b/battler-wamprat/src/lib.rs
@@ -200,7 +200,7 @@
 //!     subscriber.wait_until_ready().await.unwrap();
 //!
 //!     // Subscribe.
-//!     let (ping_tx, mut ping_rx) = broadcast::channel(16);
+//!     let (ping_tx, mut ping_rx) = broadcast::channel(48);
 //!     subscriber
 //!         .subscribe(
 //!             Uri::try_from("com.battler_wamprat.ping").unwrap(),
@@ -352,7 +352,7 @@
 //!     subscriber.wait_until_ready().await.unwrap();
 //!
 //!     // Subscribe.
-//!     let (ping_tx, mut ping_rx) = broadcast::channel(16);
+//!     let (ping_tx, mut ping_rx) = broadcast::channel(48);
 //!     subscriber
 //!         .subscribe_pattern_matched(PingEventHandler { ping_tx })
 //!         .await

--- a/battler-wamprat/src/peer/peer.rs
+++ b/battler-wamprat/src/peer/peer.rs
@@ -631,9 +631,9 @@ where
         procedures: impl Iterator<Item = (WildcardUri, PreregisteredProcedure)>,
     ) -> Self {
         let peer = Arc::new(peer);
-        let (session_established_tx, session_established_rx) = broadcast::channel(16);
-        let (session_ready_tx, session_ready_rx) = broadcast::channel(16);
-        let (session_finished_tx, session_finished_rx) = broadcast::channel(16);
+        let (session_established_tx, session_established_rx) = broadcast::channel(48);
+        let (session_ready_tx, session_ready_rx) = broadcast::channel(48);
+        let (session_finished_tx, session_finished_rx) = broadcast::channel(48);
 
         Self {
             peer: peer.clone(),
@@ -658,8 +658,8 @@ where
     pub fn start(self) -> (PeerHandle<S>, JoinHandle<()>) {
         let peer = self.peer.clone();
         let subscriber = self.subscriber.clone();
-        let (cancel_tx, cancel_rx) = broadcast::channel(16);
-        let (error_tx, error_rx) = broadcast::channel(16);
+        let (cancel_tx, cancel_rx) = broadcast::channel(48);
+        let (error_tx, error_rx) = broadcast::channel(48);
         let peer_state = self.peer_state.clone();
         let session_established_rx = self.session_established_rx.resubscribe();
         let session_ready_rx = self.session_ready_rx.resubscribe();
@@ -784,7 +784,7 @@ where
         procedure: Arc<Box<dyn Procedure>>,
         mut procedure_message_rx: broadcast::Receiver<ProcedureMessage>,
     ) {
-        let (invocation_done_tx, mut invocation_done_rx) = mpsc::channel(16);
+        let (invocation_done_tx, mut invocation_done_rx) = mpsc::channel(48);
         let mut invocations = HashMap::default();
         loop {
             tokio::select! {

--- a/battler-wamprat/src/peer/peer.rs
+++ b/battler-wamprat/src/peer/peer.rs
@@ -248,6 +248,7 @@ pub struct PeerHandle<S> {
     peer_state: Arc<RwLock<PeerState>>,
     session_established_rx: broadcast::Receiver<()>,
     session_ready_rx: broadcast::Receiver<()>,
+    session_finished_rx: broadcast::Receiver<()>,
 }
 
 impl<S> PeerHandle<S>
@@ -268,6 +269,11 @@ where
     /// running.
     pub fn error_rx(&self) -> broadcast::Receiver<ChannelTransmittableError> {
         self.error_rx.resubscribe()
+    }
+
+    /// Receiver channel for a single session finishing, for reconnection logic.
+    pub fn session_finished_rx(&self) -> broadcast::Receiver<()> {
+        self.session_finished_rx.resubscribe()
     }
 
     /// The current session ID, as given by the router.
@@ -557,6 +563,7 @@ where
             peer_state: self.peer_state.clone(),
             session_established_rx: self.session_established_rx.resubscribe(),
             session_ready_rx: self.session_ready_rx.resubscribe(),
+            session_finished_rx: self.session_finished_rx.resubscribe(),
         }
     }
 }
@@ -608,6 +615,8 @@ pub struct Peer<S> {
     session_established_rx: broadcast::Receiver<()>,
     session_ready_tx: broadcast::Sender<()>,
     session_ready_rx: broadcast::Receiver<()>,
+    session_finished_tx: broadcast::Sender<()>,
+    session_finished_rx: broadcast::Receiver<()>,
 }
 
 impl<S> Peer<S>
@@ -624,6 +633,7 @@ where
         let peer = Arc::new(peer);
         let (session_established_tx, session_established_rx) = broadcast::channel(16);
         let (session_ready_tx, session_ready_rx) = broadcast::channel(16);
+        let (session_finished_tx, session_finished_rx) = broadcast::channel(16);
 
         Self {
             peer: peer.clone(),
@@ -637,6 +647,8 @@ where
             session_established_rx,
             session_ready_tx,
             session_ready_rx,
+            session_finished_tx,
+            session_finished_rx,
         }
     }
 
@@ -651,6 +663,7 @@ where
         let peer_state = self.peer_state.clone();
         let session_established_rx = self.session_established_rx.resubscribe();
         let session_ready_rx = self.session_ready_rx.resubscribe();
+        let session_finished_rx = self.session_finished_rx.resubscribe();
         let start_handle = tokio::spawn(self.run(cancel_rx, error_tx));
         (
             PeerHandle {
@@ -661,6 +674,7 @@ where
                 peer_state,
                 session_established_rx,
                 session_ready_rx,
+                session_finished_rx,
             },
             start_handle,
         )
@@ -695,6 +709,8 @@ where
         loop {
             tokio::select! {
                 _ = session_finished_rx.recv() => {
+                    *self.peer_state.write().await = PeerState::Disconnected;
+                    self.session_finished_tx.send(()).ok();
                     break
                 }
                 _ = cancel_rx.recv() => {

--- a/battler-wamprat/tests/pub_sub_test.rs
+++ b/battler-wamprat/tests/pub_sub_test.rs
@@ -310,9 +310,13 @@ async fn resubscribes_on_reconnect() {
         Ok(())
     );
 
+    let mut subscriber_session_finished_rx = subscriber_handle.session_finished_rx();
+
     // Stop the router to disconnect the peer.
     router_handle.cancel().unwrap();
     router_join_handle.await.unwrap();
+
+    subscriber_session_finished_rx.recv().await.unwrap();
 
     // Restart the router.
     let (router_handle, router_join_handle) = start_router(8889).await.unwrap();
@@ -358,8 +362,13 @@ async fn resubscribes_on_reconnect() {
         Ok(())
     );
 
+    let mut subscriber_session_finished_rx = subscriber_handle.session_finished_rx();
+
     router_handle.cancel().unwrap();
     router_join_handle.await.unwrap();
+
+    subscriber_session_finished_rx.recv().await.unwrap();
+
     let (router_handle, router_join_handle) = start_router(8889).await.unwrap();
     subscriber_handle.wait_until_ready().await.unwrap();
 

--- a/battler-wamprat/tests/pub_sub_test.rs
+++ b/battler-wamprat/tests/pub_sub_test.rs
@@ -168,7 +168,7 @@ async fn receives_events() {
     subscriber_handle.wait_until_ready().await.unwrap();
 
     // Create a subscription that writes events to a channel.
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         subscriber_handle
             .subscribe(
@@ -299,7 +299,7 @@ async fn resubscribes_on_reconnect() {
     subscriber_handle.wait_until_ready().await.unwrap();
 
     // Create a subscription that writes events to a channel.
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         subscriber_handle
             .subscribe(
@@ -448,7 +448,7 @@ async fn retries_publish_during_reconnect() {
     subscriber_handle.wait_until_ready().await.unwrap();
 
     // Create a subscription that writes events to a channel.
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         subscriber_handle
             .subscribe(
@@ -533,7 +533,7 @@ async fn receives_pattern_based_events() {
     subscriber_handle.wait_until_ready().await.unwrap();
 
     // Create a subscription that writes events to a channel.
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         subscriber_handle
             .subscribe_pattern_matched(MessageEventHandler { events_tx })
@@ -660,7 +660,7 @@ async fn receives_pattern_based_events_with_generator() {
     subscriber_handle.wait_until_ready().await.unwrap();
 
     // Create a subscription that writes events to a channel.
-    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (events_tx, mut events_rx) = broadcast::channel(48);
     assert_matches::assert_matches!(
         subscriber_handle
             .subscribe_pattern_matched_with_generator(

--- a/battler-wamprat/tests/pub_sub_test.rs
+++ b/battler-wamprat/tests/pub_sub_test.rs
@@ -268,19 +268,23 @@ async fn resubscribes_on_reconnect() {
     let (router_handle, router_join_handle) = start_router(8889).await.unwrap();
 
     // Create a publisher and subscriber.
-    let (publisher_handle, publisher_join_handle) = PeerBuilder::new(PeerConnectionType::Remote(
+    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(
         format!("ws://{}", router_handle.local_addr()),
-    ))
-    .start(
+    ));
+    publisher_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    publisher_builder.connection_config_mut().max_consecutive_failures = 100;
+    let (publisher_handle, publisher_join_handle) = publisher_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     publisher_handle.wait_until_ready().await.unwrap();
 
-    let (subscriber_handle, subscriber_handle_join_handle) = PeerBuilder::new(
-        PeerConnectionType::Remote(format!("ws://{}", router_handle.local_addr())),
-    )
-    .start(
+    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(
+        format!("ws://{}", router_handle.local_addr()),
+    ));
+    subscriber_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    subscriber_builder.connection_config_mut().max_consecutive_failures = 100;
+    let (subscriber_handle, subscriber_handle_join_handle) = subscriber_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
@@ -405,19 +409,23 @@ async fn retries_publish_during_reconnect() {
     let (router_handle, router_join_handle) = start_router(0).await.unwrap();
 
     // Create a publisher and subscriber.
-    let (publisher_handle, publisher_join_handle) = PeerBuilder::new(PeerConnectionType::Remote(
+    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(
         format!("ws://{}", router_handle.local_addr()),
-    ))
-    .start(
+    ));
+    publisher_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    publisher_builder.connection_config_mut().max_consecutive_failures = 100;
+    let (publisher_handle, publisher_join_handle) = publisher_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     publisher_handle.wait_until_ready().await.unwrap();
 
-    let (subscriber_handle, subscriber_handle_join_handle) = PeerBuilder::new(
-        PeerConnectionType::Remote(format!("ws://{}", router_handle.local_addr())),
-    )
-    .start(
+    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(
+        format!("ws://{}", router_handle.local_addr()),
+    ));
+    subscriber_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    subscriber_builder.connection_config_mut().max_consecutive_failures = 100;
+    let (subscriber_handle, subscriber_handle_join_handle) = subscriber_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );

--- a/battler-wamprat/tests/pub_sub_test.rs
+++ b/battler-wamprat/tests/pub_sub_test.rs
@@ -268,22 +268,30 @@ async fn resubscribes_on_reconnect() {
     let (router_handle, router_join_handle) = start_router(8889).await.unwrap();
 
     // Create a publisher and subscriber.
-    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(
-        format!("ws://{}", router_handle.local_addr()),
-    ));
-    publisher_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    publisher_builder.connection_config_mut().max_consecutive_failures = 100;
+    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        router_handle.local_addr()
+    )));
+    publisher_builder.connection_config_mut().reconnect_delay =
+        std::time::Duration::from_millis(50);
+    publisher_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     let (publisher_handle, publisher_join_handle) = publisher_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     publisher_handle.wait_until_ready().await.unwrap();
 
-    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(
-        format!("ws://{}", router_handle.local_addr()),
-    ));
-    subscriber_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    subscriber_builder.connection_config_mut().max_consecutive_failures = 100;
+    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        router_handle.local_addr()
+    )));
+    subscriber_builder.connection_config_mut().reconnect_delay =
+        std::time::Duration::from_millis(50);
+    subscriber_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     let (subscriber_handle, subscriber_handle_join_handle) = subscriber_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
@@ -409,22 +417,30 @@ async fn retries_publish_during_reconnect() {
     let (router_handle, router_join_handle) = start_router(0).await.unwrap();
 
     // Create a publisher and subscriber.
-    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(
-        format!("ws://{}", router_handle.local_addr()),
-    ));
-    publisher_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    publisher_builder.connection_config_mut().max_consecutive_failures = 100;
+    let mut publisher_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        router_handle.local_addr()
+    )));
+    publisher_builder.connection_config_mut().reconnect_delay =
+        std::time::Duration::from_millis(50);
+    publisher_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     let (publisher_handle, publisher_join_handle) = publisher_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     publisher_handle.wait_until_ready().await.unwrap();
 
-    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(
-        format!("ws://{}", router_handle.local_addr()),
-    ));
-    subscriber_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    subscriber_builder.connection_config_mut().max_consecutive_failures = 100;
+    let mut subscriber_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        router_handle.local_addr()
+    )));
+    subscriber_builder.connection_config_mut().reconnect_delay =
+        std::time::Duration::from_millis(50);
+    subscriber_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     let (subscriber_handle, subscriber_handle_join_handle) = subscriber_builder.start(
         create_peer("publisher").unwrap(),
         Uri::try_from(REALM).unwrap(),

--- a/battler-wamprat/tests/pub_sub_test.rs
+++ b/battler-wamprat/tests/pub_sub_test.rs
@@ -621,7 +621,7 @@ async fn receives_pattern_based_events_with_generator() {
         PeerConnectionType::Remote(format!("ws://{}", router_handle.local_addr())),
     )
     .start(
-        create_peer("publisher").unwrap(),
+        create_peer("subscriber").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     subscriber_handle.wait_until_ready().await.unwrap();

--- a/battler-wamprat/tests/rpc_test.rs
+++ b/battler-wamprat/tests/rpc_test.rs
@@ -191,7 +191,9 @@ async fn registers_methods_on_reconnect() {
         router_handle.local_addr()
     )));
     peer_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    peer_builder.connection_config_mut().max_consecutive_failures = 100;
+    peer_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     peer_builder.add_procedure(Uri::try_from("com.battler.add2").unwrap(), AddHandler);
     let (callee_handle, callee_join_handle) = peer_builder.start(
         create_peer("callee").unwrap(),
@@ -251,7 +253,9 @@ async fn retries_call_during_reconnect() {
         router_handle.local_addr()
     )));
     callee_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    callee_builder.connection_config_mut().max_consecutive_failures = 100;
+    callee_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     callee_builder.add_procedure(Uri::try_from("com.battler.add2").unwrap(), AddHandler);
     let (callee_handle, callee_join_handle) = callee_builder.start(
         create_peer("callee").unwrap(),
@@ -264,7 +268,9 @@ async fn retries_call_during_reconnect() {
         router_handle.local_addr()
     )));
     caller_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
-    caller_builder.connection_config_mut().max_consecutive_failures = 100;
+    caller_builder
+        .connection_config_mut()
+        .max_consecutive_failures = 100;
     let (caller_handle, caller_join_handle) = caller_builder.start(
         create_peer("caller").unwrap(),
         Uri::try_from(REALM).unwrap(),

--- a/battler-wamprat/tests/rpc_test.rs
+++ b/battler-wamprat/tests/rpc_test.rs
@@ -190,6 +190,8 @@ async fn registers_methods_on_reconnect() {
         "ws://{}",
         router_handle.local_addr()
     )));
+    peer_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    peer_builder.connection_config_mut().max_consecutive_failures = 100;
     peer_builder.add_procedure(Uri::try_from("com.battler.add2").unwrap(), AddHandler);
     let (callee_handle, callee_join_handle) = peer_builder.start(
         create_peer("callee").unwrap(),
@@ -244,21 +246,26 @@ async fn retries_call_during_reconnect() {
     // Start a router.
     let (router_handle, router_join_handle) = start_router(0).await.unwrap();
 
-    let mut peer_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+    let mut callee_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
         "ws://{}",
         router_handle.local_addr()
     )));
-    peer_builder.add_procedure(Uri::try_from("com.battler.add2").unwrap(), AddHandler);
-    let (callee_handle, callee_join_handle) = peer_builder.start(
+    callee_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    callee_builder.connection_config_mut().max_consecutive_failures = 100;
+    callee_builder.add_procedure(Uri::try_from("com.battler.add2").unwrap(), AddHandler);
+    let (callee_handle, callee_join_handle) = callee_builder.start(
         create_peer("callee").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );
     callee_handle.wait_until_ready().await.unwrap();
 
-    let (caller_handle, caller_join_handle) = PeerBuilder::new(PeerConnectionType::Remote(
-        format!("ws://{}", router_handle.local_addr()),
-    ))
-    .start(
+    let mut caller_builder = PeerBuilder::new(PeerConnectionType::Remote(format!(
+        "ws://{}",
+        router_handle.local_addr()
+    )));
+    caller_builder.connection_config_mut().reconnect_delay = std::time::Duration::from_millis(50);
+    caller_builder.connection_config_mut().max_consecutive_failures = 100;
+    let (caller_handle, caller_join_handle) = caller_builder.start(
         create_peer("caller").unwrap(),
         Uri::try_from(REALM).unwrap(),
     );

--- a/battler-wamprat/tests/rpc_test.rs
+++ b/battler-wamprat/tests/rpc_test.rs
@@ -197,9 +197,13 @@ async fn registers_methods_on_reconnect() {
     );
     callee_handle.wait_until_ready().await.unwrap();
 
+    let mut callee_session_finished_rx = callee_handle.session_finished_rx();
+
     // Stop the router to disconnect the peer.
     router_handle.cancel().unwrap();
     router_join_handle.await.unwrap();
+
+    callee_session_finished_rx.recv().await.unwrap();
 
     // Restart the router.
     let (router_handle, router_join_handle) = start_router(8888).await.unwrap();

--- a/battler/Cargo.toml
+++ b/battler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battler"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Pokémon battle engine for Rust."
 authors = ["Jackson Nestelroad <jackson@nestelroad.com>"]

--- a/battler/src/battle/core_battle.rs
+++ b/battler/src/battle/core_battle.rs
@@ -1900,8 +1900,8 @@ impl<'d> CoreBattle<'d> {
                 context.battle_mut().log(battle_log_entry!("tie"));
             }
         }
-        context.battle_mut().ended = true;
         context.battle_mut().log.commit();
+        context.battle_mut().ended = true;
         Self::clear_requests(context)?;
         Ok(())
     }


### PR DESCRIPTION
1. Increase general channel sizes (16 => 48).
2. Control state synchronously for battles in battler-service.
3. Shut down battles in battler-service without holding lock.
4. Attempt to retry unwrapping a battle when deleting it in battler-service.
5. Several test fixes in battler-service and battler-service-producer.
6. Close WAMP stream with timeout.
7. Use UnboundedSender/Receiver for DirectMessageStream.
8. Disconnect WAMP peers without holding lock.
9. Remove registrations/subscriptions synchronously with confirmation message.
10. Do not remove procedure during unregistration when other callees are registered.
11. (critical) Subscribe to RPC yields from callee session before sending Invocation message.
12. Several battler-wamp and battler-wamprat test fixes.